### PR TITLE
Fix tox.

### DIFF
--- a/requirements_tox.txt
+++ b/requirements_tox.txt
@@ -1,0 +1,6 @@
+# Until Kazoo SASL patches are upstreamed
+#
+# It is necessary to install kazoo from repo first when running tox, as
+# treadmill downstream will ask for kazoo-2.4.0.dev and this does not exist
+# in pypi.
+git+https://github.com/ceache/kazoo.git@puresasl#egg=kazoo [sasl]

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ envlist = py34,py35,py36,pylint,docs
 
 [testenv]
 deps =
+    -r{toxinidir}/requirements_tox.txt
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 install_command =


### PR DESCRIPTION
Treadmill (downstream) will ask for kazoo=2.4.0.dev0 as dependency, but
it does not exist in pypi. Force installing kazoo from git repo first,
before installing other requirements.