### PR TITLE
DNS Monitor POC complete

### DIFF
--- a/lib/python/treadmill_aws/awscontext.py
+++ b/lib/python/treadmill_aws/awscontext.py
@@ -62,7 +62,8 @@ class AWSContext(object):
         if self._ipaclient:
             return self._ipaclient
 
-        self._ipaclient = ipaclient.IPAClient(self.ipa_domain, self.ipa_certs)
+        self._ipaclient = ipaclient.IPAClient(certs=self.ipa_certs,
+                                              domain=self.ipa_domain)
         return self._ipaclient
 
     @property

--- a/lib/python/treadmill_aws/dnsmonitor.py
+++ b/lib/python/treadmill_aws/dnsmonitor.py
@@ -1,0 +1,203 @@
+""" ZK to IPA DNS watch/update daemon and helper functions """
+
+import logging
+import os
+import re
+from treadmill.dirwatch import DirWatcher
+from treadmill_aws.ipaclient import filter_raw_records
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_WEIGHT = 10
+DEFAULT_PRIORITY = 10
+
+
+def find_app_dns(ipaclient, server, protocol, app_name):
+    """Returns a list of SRV records in dictionary format matching app_name.
+    """
+    idnsname = '_{server}._{protocol}.{app_name}.{domain}'.format(
+        server=server,
+        protocol=protocol,
+        app_name=app_name,
+        domain=ipaclient.domain)
+
+    _LOGGER.debug('Generated idnsname: %s', idnsname)
+
+    return ipaclient.get_ipa_dns(idnsname=idnsname)
+
+
+def generate_srv_record(cell_name, server, app_name, protocol, endpoints):
+    """Generates SRV DNS records to send to IPA.
+    """
+
+    host, port = endpoints[0]
+    idnsname = '_{server}._{protocol}.{app_name}.{cell_name}'.format(
+        app_name=app_name,
+        cell_name=cell_name,
+        protocol=protocol,
+        server=server)
+
+    record = '{weight} {priority} {port} {host}.'.format(
+        weight=DEFAULT_WEIGHT,
+        priority=DEFAULT_PRIORITY,
+        port=port,
+        host=host)
+
+    dns_record = {'type': 'srvrecord',
+                  'idnsname': idnsname,
+                  'record': record}
+
+    _LOGGER.debug('Generated DNS record: %s', dns_record)
+    return dns_record
+
+
+def get_filesystem_context(endpoint_dir, path):
+    """ Returns dict representing file in ZK.
+    """
+
+    proid, file_name = path.split('/')[-2:]
+    proid_dir = '{path}/{proid}'.format(path=endpoint_dir, proid=proid)
+
+    app, protocol, server = re.search(
+        r'([a-z0-9-]+)#\d*:(\w+):(\w+)', file_name).groups()
+
+    return {'app': app,
+            'file_name': file_name,
+            'proid_dir': proid_dir,
+            'protocol': protocol,
+            'server': server}
+
+
+def get_zk_target_from_file(path):
+    """ Returns host and port from Zookeeper mirror on disk.
+    """
+    with open(path) as f:
+        hostname, port = f.read().split(':')
+    return hostname, int(port)
+
+
+def mirror_zookeeper(cell_name, ipaclient, zk_records):
+    """This function gets a list of records from Zookeeper and from IPA
+       DNS, generates an index of each record list, then adds any new
+       records & deletes any old records by comparing each list against
+       the other's index.
+    """
+    raw_records = ipaclient.get_ipa_dns()
+    ipa_records = filter_raw_records(cell_name=cell_name,
+                                     raw_records=raw_records,
+                                     record_type='srvrecord')
+
+    zk_record_list = [z['record'] for z in zk_records]
+    ipa_record_list = [i['record'] for i in ipa_records]
+
+    # Add new records from Zookeeper
+    for z_rec in zk_records:
+        if z_rec['record'] not in ipa_record_list:
+            _LOGGER.debug('Add record: %s', z_rec)
+            ipaclient.add_ipa_dns(record_type='srvrecord',
+                                  record_name=z_rec['idnsname'],
+                                  record_value=z_rec['record'])
+
+    # Delete bad records in IPA DNS
+    for i_rec in ipa_records:
+        if i_rec['record'] not in zk_record_list:
+            _LOGGER.debug('Delete record: %s', i_rec)
+            ipaclient.del_ipa_dns(record_type='srvrecord',
+                                  record_name=i_rec['idnsname'],
+                                  record_value=i_rec['record'])
+
+
+class DNSMonitor():
+    """Class to monitor ZK directory and reflect changes to IPA DNS records.
+    """
+
+    def __init__(self, cell_name, ipaclient, zkfs_dir):
+        """ Environment setup. """
+        _LOGGER.info('Montoring directory: %s', zkfs_dir)
+        self.cell_name = cell_name
+        self.endpoint_dir = zkfs_dir
+        self.ipaclient = ipaclient
+        self.on_created = self._on_created
+        self.on_deleted = self._on_deleted
+
+    def _on_created(self, path):
+        """ Executes on creation of new ZK endpoint """
+        context = get_filesystem_context(endpoint_dir=self.endpoint_dir,
+                                         path=path)
+        _LOGGER.info('Found new endpoint %s/%s',
+                     context['proid_dir'],
+                     context['file_name'])
+
+        # Get list of endpoints from new ZK entry
+        endpoints = [get_zk_target_from_file(path=path)]
+
+        # Create DNS entries for new endpoints
+        dns_record = generate_srv_record(cell_name=self.cell_name,
+                                         server=context['server'],
+                                         app_name=context['app'],
+                                         protocol=context['protocol'],
+                                         endpoints=endpoints)
+
+        # Submit DNS record to freeIPA
+        self.ipaclient.add_ipa_dns(record_type='srvrecord',
+                                   record_name=dns_record['idnsname'],
+                                   record_value=dns_record['record'])
+        _LOGGER.info('Record added: %s', path)
+
+    def _on_deleted(self, path):
+        """Executes on deletion of existing ZK endpoint.
+        """
+        _LOGGER.info('Record deleted: %s', path)
+        self.sync()
+
+    def run(self):
+        """Start daemon. Run initial sync, then watch for changes.
+        """
+        watch = DirWatcher()
+        watch.on_created = self._on_created
+        watch.on_deleted = self._on_deleted
+        watch.add_dir(self.endpoint_dir)
+
+        # Run an initial sync when daemon starts
+        self.sync()
+
+        # Main loop
+        while True:
+            if watch.wait_for_events(5):
+                watch.process_events()
+
+    def sync(self):
+        """Generate list of DNS records derived from ZK filesystem mirror,
+           then mirror them to freeIPA's DNS.
+        """
+        mirror_list = []
+        zk_context = []
+
+        # Generate list of app endpoints owned by proid
+        app_full_paths = ['{path}/{app}'.format(path=self.endpoint_dir,
+                                                app=app)
+                          for app in os.listdir(self.endpoint_dir)]
+
+        # Generate app context and endpoints for each discovered app
+        for path in app_full_paths:
+            context = get_filesystem_context(endpoint_dir=self.endpoint_dir,
+                                             path=path)
+            endpoints = [get_zk_target_from_file(path=path)]
+
+            if context and endpoints:
+                zk_context.append({'context': context,
+                                   'endpoints': endpoints})
+
+        # Generate DNS record for each app
+        for app in zk_context:
+            rec = generate_srv_record(cell_name=self.cell_name,
+                                      server=app['context']['server'],
+                                      app_name=app['context']['app'],
+                                      protocol=app['context']['protocol'],
+                                      endpoints=app['endpoints'])
+            if rec:
+                mirror_list.append(rec)
+
+        mirror_zookeeper(cell_name=self.cell_name,
+                         ipaclient=self.ipaclient,
+                         zk_records=mirror_list)

--- a/lib/python/treadmill_aws/hostmanager.py
+++ b/lib/python/treadmill_aws/hostmanager.py
@@ -17,7 +17,7 @@ def render_manifest(key_value_pairs, url_list=None):
                                       'cloud-config'))
 
     # Generate MIME from cloud-init template and attach to MIME message body
-    ipa_join_template = '''# install ipa-client
+    domain_join_template = '''# install ipa-client
 packages:
  - ipa-client
 #
@@ -32,7 +32,7 @@ runcmd:
   --mkhomedir \
   --no-ntp \
   --unattended'''
-    combined_userdata.attach(MIMEText(ipa_join_template, 'cloud-config'))
+    combined_userdata.attach(MIMEText(domain_join_template, 'cloud-config'))
 
     # Format and attach any URL includes
     if url_list:
@@ -58,7 +58,7 @@ def create_host(ec2_conn, ipa_client, image_id, count, domain,
 
     for _ in range(count):
         hostname = generate_hostname(domain=domain, role=role)
-        ipa_host = ipa_client.enroll_ipa_host(hostname=hostname)
+        ipa_host = ipa_client.enroll_host(hostname=hostname)
         otp = ipa_host['result']['result']['randompassword']
         user_data = render_manifest(key_value_pairs={'hostname': hostname,
                                                      'otp': otp})
@@ -82,7 +82,7 @@ def create_host(ec2_conn, ipa_client, image_id, count, domain,
 def delete_hosts(ec2_conn, ipa_client, hostnames):
     """ Unenrolls hosts from IPA and AWS """
     for hostname in hostnames:
-        ipa_client.unenroll_ipa_host(hostname=hostname)
+        ipa_client.unenroll_host(hostname=hostname)
         ec2client.delete_instance(ec2_conn, hostname=hostname)
 
 
@@ -93,6 +93,6 @@ def find_hosts(ipa_client, pattern=None):
     if pattern is None:
         pattern = ''
 
-    return ipa_client.get_ipa_hosts(
+    return ipa_client.get_hosts(
         pattern=pattern
     )

--- a/lib/python/treadmill_aws/ipaclient.py
+++ b/lib/python/treadmill_aws/ipaclient.py
@@ -11,20 +11,53 @@ _API_VERSION = '2.28'
 
 
 def get_ipa_server_from_dns(domain):
-    """ Looks up random IPA server from DNS SRV records """
+    """Looks up random IPA server from DNS SRV records.
+    """
     raw_results = [
         result.to_text() for result in
         dns.resolver.query('_kerberos._tcp.{}'.format(domain),
                            'SRV')]
-    return random.choice(raw_results).split()[-1]
+    if raw_results:
+        return random.choice(raw_results).split()[-1]
+    else:
+        raise Exception('No IPA Servers Found')
+
+
+def filter_raw_records(cell_name, raw_records, record_type):
+    """Extract and filter cell-specific typed records from IPA JSON export.
+       Returns list of dict objects that describe matching records.
+    """
+    dns_records = []
+
+    # Extract individual entries from record dump that match type, cell_name
+    for record in [fmt_rec for fmt_rec in raw_records['result']['result']
+                   if cell_name in fmt_rec['idnsname'][0] and record_type in
+                   fmt_rec.keys()]:
+
+        # IPA returns multiple records with the same idnsname
+        # as type List, and returns singleton records as type String
+        if isinstance(record[record_type], list):
+            for entry in record[record_type]:
+                dns_records.append({'type': record_type,
+                                    'dn': record['dn'],
+                                    'idnsname': record['idnsname'][0],
+                                    'record': entry})
+        else:
+            dns_records.append({'type': record_type,
+                                'dn': record['dn'],
+                                'idnsname': record['idnsname'][0],
+                                'record': record[record_type]})
+    return dns_records
 
 
 class IPAClient():
-    """ Interfaces with freeIPA API to register and deregister hosts """
+    """Interfaces with freeIPA API to register and deregister hosts.
+    """
 
-    def __init__(self, domain, certs):
-        self.domain = domain
+    def __init__(self, certs, domain):
         self.certs = certs
+        self.domain = domain
+
         # Strip trailing period as it breaks SSL
         self.ipa_server_hostn = get_ipa_server_from_dns(self.domain)[:-1]
         self.ipa_srv_address = 'https://{}/ipa'.format(self.ipa_server_hostn)
@@ -41,13 +74,19 @@ class IPAClient():
                                  auth=auth,
                                  headers=self.referer,
                                  verify=self.certs)
+
+        # FreeIPA returns an HTML document rather than JSON if creds not valid:
+        if 'Unable to verify your Kerberos credentials' in response.text:
+            raise Exception('Invalid Kerberos Credentials')
+
         if response.json()['error']:
             raise KeyError(response.json()['error']['message'])
 
         return response
 
-    def enroll_ipa_host(self, hostname):
-        """ Enroll new host with IPA server """
+    def enroll_host(self, hostname):
+        """Enroll new host with IPA server.
+        """
         payload = {'method': 'host_add',
                    'params': [[hostname],
                               {'force': True,
@@ -56,8 +95,8 @@ class IPAClient():
                    'id': 0}
         return self._post(payload=payload).json()
 
-    def unenroll_ipa_host(self, hostname):
-        """ Unenroll host from IPA server """
+    def unenroll_host(self, hostname):
+        """Unenroll host from IPA server."""
         payload = {'method': 'host_del',
                    'params': [[hostname],
                               {'updatedns': True,
@@ -65,8 +104,9 @@ class IPAClient():
                    'id': 0}
         return self._post(payload=payload).json()
 
-    def get_ipa_hosts(self, pattern=''):
-        """ Retrieve host records from IPA server """
+    def get_hosts(self, pattern=None):
+        """Retrieve host records from IPA server.
+        """
         payload = {'method': 'host_find',
                    'params': [[pattern],
                               {'version': _API_VERSION}],
@@ -77,3 +117,38 @@ class IPAClient():
         return [result
                 for hosts in resp['result']['result']
                 for result in hosts['fqdn']]
+
+    def add_dns_record(self, record_type, record_name, record_value):
+        """Add new DNS record to IPA server.
+        """
+        payload = {'method': 'dnsrecord_add',
+                   'params': [[self.domain, record_name],
+                              {record_type: record_value,
+                               'version': _API_VERSION}],
+                   'id': 0}
+        return self._post(payload=payload).json()
+
+    def del_dns_record(self, record_type, record_name, record_value):
+        """Delete DNS record from IPA server.
+        """
+        payload = {'method': 'dnsrecord_del',
+                   'params': [[self.domain, record_name],
+                              {record_type: record_value,
+                               'version': _API_VERSION}],
+                   'id': 0}
+        return self._post(payload=payload).json()
+
+    def get_dns_record(self, idnsname=None):
+        """Retrieve DNS records from IPA server.
+        """
+        if idnsname:
+            payload = {'method': 'dnsrecord_find',
+                       'params': [[self.domain, idnsname],
+                                  {'version': _API_VERSION}],
+                       'id': 0}
+        else:
+            payload = {'method': 'dnsrecord_find',
+                       'params': [[self.domain],
+                                  {'version': _API_VERSION}],
+                       'id': 0}
+        return self._post(payload=payload).json()

--- a/lib/python/treadmill_aws/sproc/dnsmonitor.py
+++ b/lib/python/treadmill_aws/sproc/dnsmonitor.py
@@ -1,0 +1,74 @@
+"""Treadmill IPA DNS manager.
+
+   This system process watches Zookeeper's data on app endpoints
+   and creates/updates/destroys IPA DNS records when app endpoints change
+"""
+import logging
+import os
+import sys
+
+import click
+
+from treadmill import context
+from treadmill import utils
+from treadmill import zknamespace as z
+from treadmill import zkutils
+from treadmill_aws import awscontext
+from treadmill_aws import dnsmonitor
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _do_watch(zkclient, zkfs_dir):
+    """Watch proid endpoints for changes.
+    """
+    dns_monitor = dnsmonitor.DNSMonitor(cell_name=context.GLOBAL.cell,
+                                        ipaclient=awscontext.GLOBAL.ipaclient,
+                                        zkfs_dir=zkfs_dir)
+
+    @zkclient.ChildrenWatch(zkfs_dir)
+    @utils.exit_on_unhandled
+    def _endpoint_change(_children):
+        _LOGGER.info(
+            'Endpoints changed! Updating DNS configuration...'
+        )
+    dns_monitor.run()
+
+
+def init():
+    """Return top level command handler.
+    """
+
+    @click.command()
+    @click.option('--no-lock', is_flag=True, default=False,
+                  help='Run without lock.')
+    @click.option('--proid', required=True,
+                  help='System proid to monitor')
+    @click.option('--root', default='/tmp/zk2fs',
+                  help='ZK2FS root directory')
+    def run(no_lock, proid, root):
+        """Run Treadmill DNS endpoint engine.
+        """
+        zkclient = context.GLOBAL.zk.conn
+
+        zkendpointpath = z.join_zookeeper_path(z.ENDPOINTS, proid)
+        zkclient.ensure_path(zkendpointpath)
+        zk2fs_endpointpath = '{}{}'.format(root, zkendpointpath)
+
+        if not os.path.isabs(zk2fs_endpointpath):
+            _LOGGER.error('Invalid path: %s', zk2fs_endpointpath)
+            sys.exit(1)
+
+        if no_lock:
+            _do_watch(zkclient=zkclient,
+                      zkfs_dir=zk2fs_endpointpath)
+        else:
+            lock = zkutils.make_lock(
+                zkclient, z.path.election(__name__)
+            )
+            _LOGGER.info('Waiting for leader lock.')
+            with lock:
+                _do_watch(zkclient=zkclient,
+                          zkfs_dir=zk2fs_endpointpath)
+
+    return run

--- a/tests/dnsmonitor_test.py
+++ b/tests/dnsmonitor_test.py
@@ -1,0 +1,207 @@
+""" DNS Daemon tests """
+# Suppress pylint warnings concerning access to protected members
+# pylint: disable=W0212
+# Suppress pylint warnings concerning imports of mocked classes
+# pylint: disable=W0611
+
+import os
+import unittest
+
+import mock
+
+import treadmill
+import treadmill_aws
+from treadmill_aws import dnsmonitor
+from treadmill_aws import ipaclient
+
+
+class DNSMonitorHelperTests(unittest.TestCase):
+    """Test DNSDaemon helper functions.
+    """
+
+    @mock.patch('treadmill_aws.ipaclient')
+    def test_find_app_dns(self, mock_ipaclient):
+        """Test that idnsname is rendered correctly.
+        """
+
+        mock_ipaclient.domain = 'foo.com'
+
+        dnsmonitor.find_app_dns(
+            ipaclient=mock_ipaclient,
+            server='ssh',
+            protocol='tcp',
+            app_name='fooapi')
+
+        mock_ipaclient.get_ipa_dns.assert_called_with(
+            idnsname='_ssh._tcp.fooapi.foo.com')
+
+    def test_generate_srv_record(self):
+        """Test that SRV records are rendered correctly.
+        """
+
+        result = dnsmonitor.generate_srv_record(
+            cell_name='subnet-123',
+            server='ssh',
+            protocol='tcp',
+            app_name='fooapi',
+            endpoints=[('host1.foo.com', 5000)])
+
+        assert result == {'idnsname': '_ssh._tcp.fooapi.subnet-123',
+                          'record': '10 10 5000 host1.foo.com.',
+                          'type': 'srvrecord'}
+
+    def test_get_filesystem_context(self):
+        """Test that script parses ZK endpoint path correctly.
+        """
+
+        result = dnsmonitor.get_filesystem_context(
+            endpoint_dir='/tmp/foo/endpoints',
+            path='/tmp/foo/endpoints/proid/appname#001:tcp:ssh')
+
+        assert result == {'app': 'appname',
+                          'file_name': 'appname#001:tcp:ssh',
+                          'proid_dir': '/tmp/foo/endpoints/proid',
+                          'protocol': 'tcp',
+                          'server': 'ssh'}
+
+    def test_zk_target_from_file(self):
+        """Test that script parses ZK endpoint file on disk correctly.
+        """
+
+        with mock.patch("builtins.open",
+                        mock.mock_open(
+                            read_data='host1.foo.com:5000')) as mock_file:
+
+            result = dnsmonitor.get_zk_target_from_file('/foo')
+
+        assert result == ('host1.foo.com', 5000)
+
+    @mock.patch('treadmill_aws.ipaclient')
+    def test_mirror_zookeeper(self, mock_ipaclient):
+        """Test mirror_zookeeper operations:
+           - Comparison of equal ZK and IPA records - no changes
+           - New ZK records - Add ZK records to IPA
+           - Removed ZK records - Remove ZK records from IPA
+        """
+
+        sample_dns_records = [
+            {'dn': 'idnsname=_http._tcp.testapi1.subnet-123,'
+                   'idnsname=foo.com.,cn=dns,dc=foo,dc=com',
+             'idnsname': '_http._tcp.testapi1.subnet-123',
+             'record': '10 10 1234 host1.foo.com.',
+             'type': 'srvrecord'}]
+
+        # Case 1- equal ZK and IPA record sets.
+        dnsmonitor.filter_raw_records = mock.MagicMock(
+            return_value=sample_dns_records)
+
+        dnsmonitor.mirror_zookeeper(cell_name='subnet123',
+                                    ipaclient=mock_ipaclient,
+                                    zk_records=sample_dns_records)
+
+        assert mock_ipaclient.add_ipa_dns.call_count == 0
+        assert mock_ipaclient.del_ipa_dns.call_count == 0
+
+        mock_ipaclient.reset_mock()
+
+        # Case 2- New ZK record, missing in IPA
+        dnsmonitor.filter_raw_records = mock.MagicMock(
+            return_value=[])
+
+        dnsmonitor.mirror_zookeeper(cell_name='subnet123',
+                                    ipaclient=mock_ipaclient,
+                                    zk_records=sample_dns_records)
+
+        assert mock_ipaclient.add_ipa_dns.call_count == 1
+        assert mock_ipaclient.del_ipa_dns.call_count == 0
+
+        mock_ipaclient.reset_mock()
+
+        # Case 3- ZK record deleted, present in IPA
+        dnsmonitor.filter_raw_records = mock.MagicMock(
+            return_value=sample_dns_records)
+
+        dnsmonitor.mirror_zookeeper(cell_name='subnet123',
+                                    ipaclient=mock_ipaclient,
+                                    zk_records=[])
+
+        assert mock_ipaclient.add_ipa_dns.call_count == 0
+        assert mock_ipaclient.del_ipa_dns.call_count == 1
+
+
+class DNSMonitorTests(unittest.TestCase):
+    """ Tests DNSMonitor interface """
+
+    @mock.patch('treadmill_aws.ipaclient')
+    def test_on_created(self, mock_ipaclient):
+        """Test end-to-end creation of IPA records.
+        """
+        client = dnsmonitor.DNSMonitor(cell_name='subnet123',
+                                       ipaclient=mock_ipaclient,
+                                       zkfs_dir='/foo')
+
+        # Populate the get_zk_target_from_file:
+        with mock.patch("builtins.open",
+                        mock.mock_open(
+                            read_data='host1.foo.com:5000')) as mock_file:
+
+            client._on_created('/foo/endpoints/proid/appname#001:tcp:ssh')
+
+        mock_ipaclient.add_ipa_dns.assert_called_with(
+            record_name='_ssh._tcp.appname.subnet123',
+            record_type='srvrecord',
+            record_value='10 10 5000 host1.foo.com.')
+
+    @mock.patch('treadmill_aws.ipaclient')
+    def test_on_deleted(self, mock_ipaclient):
+        """Test that client.sync() gets called when _on_deleted is called.
+        """
+        client = dnsmonitor.DNSMonitor(cell_name='subnet123',
+                                       ipaclient=mock_ipaclient,
+                                       zkfs_dir='/foo')
+        client.sync = mock.MagicMock()
+        client._on_deleted('/foo')
+
+        assert client.sync.call_count == 1
+
+    @mock.patch('treadmill_aws.ipaclient')
+    def test_sync(self, mock_ipaclient):
+        """Test ZK record generation operations.
+        """
+        client = dnsmonitor.DNSMonitor(cell_name='subnet123',
+                                       ipaclient=mock_ipaclient,
+                                       zkfs_dir='/foo')
+
+        dnsmonitor.mirror_zookeeper = mock.MagicMock()
+
+        with mock.patch('os.listdir') as mocked_listdir:
+            # Populate the get_zk_target_from_file:
+            with mock.patch("builtins.open",
+                            mock.mock_open(
+                                read_data='host1.foo.com:5000')) as mock_file:
+
+                # Mock directory with one file target:
+                mocked_listdir.return_value = ['appname#001:tcp:ssh']
+
+                client.sync()
+
+                dnsmonitor.mirror_zookeeper.assert_called_with(
+                    cell_name='subnet123',
+                    ipaclient=mock_ipaclient,
+                    zk_records=[{'idnsname': '_ssh._tcp.appname.subnet123',
+                                 'record': '10 10 5000 host1.foo.com.',
+                                 'type': 'srvrecord'}])
+
+                # Mock directory with no targets:
+                mocked_listdir.return_value = []
+
+                client.sync()
+
+                dnsmonitor.mirror_zookeeper.assert_called_with(
+                    cell_name='subnet123',
+                    ipaclient=mock_ipaclient,
+                    zk_records=[])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/ec2client_test.py
+++ b/tests/ec2client_test.py
@@ -20,7 +20,6 @@ class EC2ClientTest(unittest.TestCase):
         rendered_tags = [{'ResourceType': 'instance',
                           'Tags': [{'Value': 'host.foo.com', 'Key': 'Name'},
                                    {'Value': 'foo', 'Key': 'Role'}]}]
-        print(rendered_tags)
 
         self.assertEqual(aws.build_tags(hostname, role), rendered_tags)
 

--- a/tests/ipaclient_test.py
+++ b/tests/ipaclient_test.py
@@ -1,0 +1,265 @@
+""" IPA Client tests """
+# Suppress pylint warnings concerning access to protected member _post
+# pylint: disable=W0212
+# Suppress pylint warnings concerning imports of mocked classes
+# pylint: disable=W0611
+
+import unittest
+
+import dns.resolver
+import mock
+import requests
+
+import treadmill_aws
+from treadmill_aws import aws
+from treadmill_aws import ipaclient
+
+
+class IPAHelperTests(unittest.TestCase):
+    """Test IPAClient helper functions.
+    """
+
+    fake_multi_records = {'error': None,
+                          'id': 0,
+                          'principal': 'admin@FOO.COM',
+                          'result': {
+                              'count': 3,
+                              'result': [
+                                  {'dn': 'idnsname=_http._tcp.testapi.'
+                                         'subnet-123,idnsname=foo.com.,'
+                                         'cn=dns,dc=foo,dc=com',
+                                   'idnsname': [
+                                       '_http._tcp.testapi.subnet-123'],
+                                   'srvrecord': ['10 10 1234 host1.foo.com.']},
+                                  {'dn': 'idnsname=_http._tcp.testapi2.'
+                                         'subnet-123,idnsname=foo.com.,'
+                                         'cn=dns,dc=foo,dc=com',
+                                   'idnsname': [
+                                       '_http._tcp.testapi2.subnet-123'],
+                                   'srvrecord': ['10 10 1234 host2.foo.com.']},
+                                  {'dn': 'idnsname=_http._tcp.testapi3.'
+                                         'subnet-456,idnsname=foo.com.,'
+                                         'cn=dns,dc=foo,dc=com',
+                                   'idnsname': [
+                                       '_http._tcp.testapi3.subnet-456'],
+                                   'srvrecord': ['10 10 1234 host3.foo.com.']},
+                                  {'arecord': ['192.168.0.2'],
+                                   'dn': 'idnsName=host4,idnsname='
+                                         'foo.com.,cn=dns,dc=foo,dc=com',
+                                   'idnsname': ['host4'],
+                                   'sshfprecord': ['1 1 ABC',
+                                                   '1 2 ABC 3E180D08',
+                                                   '3 1 ABC',
+                                                   '3 2 ABC 22FC10E0',
+                                                   '4 1 ABC',
+                                                   '4 2 ABC 4DDA73C1']}],
+                              'summary': None,
+                              'truncated': False},
+                          'version': '4.5.0'}
+
+    no_records = {'error': None,
+                  'id': 0,
+                  'principal': 'admin@FOO.COM',
+                  'result': {'count': 0,
+                             'result': [],
+                             'summary': None,
+                             'truncated': False},
+                  'version': '4.5.0'}
+
+    def test_get_ipa_server_from_dns(self):
+        """Test IPA server resolution from DNS.
+        """
+
+        class FakeResponse(object):
+            """Fake requests.response object.
+            """
+
+            def __init__(self, host):
+                """ Assign argument as self.host """
+                self.host = host
+
+            def to_text(self):
+                """ Return self.host when to_text() called """
+                return '0 100 88 {}.'.format(self.host)
+
+        # Test single DNS response
+        dns.resolver.query = mock.MagicMock(
+            return_value=[FakeResponse('ipa1.foo.com')])
+
+        result = ipaclient.get_ipa_server_from_dns('foo.com')
+        assert result == 'ipa1.foo.com.'
+
+        # Test multiple DNS responses
+        dns.resolver.query = mock.MagicMock(
+            return_value=[FakeResponse('ipa1.foo.com'),
+                          FakeResponse('ipa2.foo.com')])
+
+        result = ipaclient.get_ipa_server_from_dns('foo.com')
+        assert result in ['ipa1.foo.com.', 'ipa2.foo.com.']
+
+        # Test no DNS response
+        dns.resolver.query = mock.MagicMock(
+            return_value=[])
+
+        with self.assertRaises(Exception) as context:
+            result = ipaclient.get_ipa_server_from_dns('foo.com')
+            self.assertTrue('No IPA Servers Found' in context.exception)
+
+    def test_filter_raw_records(self):
+        """Test formatting and filtering JSON IPA record output.
+           Filters are based on cell name and record type.
+        """
+
+        # Test single SRV record returned
+        result = ipaclient.filter_raw_records(
+            cell_name='subnet-456',
+            raw_records=self.fake_multi_records,
+            record_type='srvrecord')
+
+        assert result == [
+            {'dn': 'idnsname=_http._tcp.testapi3.subnet-456,'
+                   'idnsname=foo.com.,cn=dns,dc=foo,dc=com',
+             'idnsname': '_http._tcp.testapi3.subnet-456',
+             'record': '10 10 1234 host3.foo.com.',
+             'type': 'srvrecord'}]
+
+        # Test multiple SRV records returned
+        result = ipaclient.filter_raw_records(
+            cell_name='subnet-123',
+            raw_records=self.fake_multi_records,
+            record_type='srvrecord')
+
+        assert result == [
+            {'dn': 'idnsname=_http._tcp.testapi.subnet-123,'
+                   'idnsname=foo.com.,cn=dns,dc=foo,dc=com',
+             'idnsname': '_http._tcp.testapi.subnet-123',
+             'record': '10 10 1234 host1.foo.com.',
+             'type': 'srvrecord'},
+            {'dn': 'idnsname=_http._tcp.testapi2.subnet-123,'
+                   'idnsname=foo.com.,cn=dns,dc=foo,dc=com',
+             'idnsname': '_http._tcp.testapi2.subnet-123',
+             'record': '10 10 1234 host2.foo.com.',
+             'type': 'srvrecord'}]
+
+        # Test no records returned
+        result = ipaclient.filter_raw_records(cell_name='subnet-123',
+                                              raw_records=self.no_records,
+                                              record_type='srvrecord')
+        assert result == []
+
+
+class IPAClientTest(unittest.TestCase):
+    """Tests IPA client interface.
+    """
+
+    class FakeResponse(object):
+        """Fake IPA response object.
+        """
+
+        def json(self=None):
+            """Fake JSON response.
+            """
+
+            return {'error': None,
+                    'result':
+                    {'result': [
+                        {'krbprincipalname': [
+                            'host/host.foo.com@FOO.COM'],
+                         'dn': 'fqdn=host.foo.com,dc=foo,dc=com',
+                         'fqdn': ['host.foo.com'],
+                         'sshpubkeyfp': [
+                             'SHA256:ZEQFEjXYEqYhtk (ssh-rsa)',
+                             'SHA256:W9J6SunkvJU (ecdsa-sha2-nistp256)',
+                             'SHA256:sT7bx2Agf6Mx0 (ssh-ed25519)'],
+                         'krbcanonicalname': [
+                             'host/host.foo.com@FOO.COM']}],
+                     'count': 1,
+                     'truncated': False,
+                     'summary': '1 hosts matched'},
+                    'id': 0,
+                    'version': '4.5.0',
+                    'principal': 'admin@FOO.COM'}
+
+    def setUp(self):
+        ipaclient.get_ipa_server_from_dns = mock.MagicMock(
+            return_value='ipa1.foo.com.')
+        self.test_client = ipaclient.IPAClient(certs='/foo', domain='foo.com')
+        self.test_client._post = mock.MagicMock()
+
+    def test_enroll_host_payload(self):
+        """Test that enroll_ipa_host formats payload correctly.
+        """
+        self.test_client.enroll_host(hostname='host.foo.com')
+        self.test_client._post.assert_called_with(
+            payload={'method': 'host_add',
+                     'id': 0, 'params': [['host.foo.com'],
+                                         {'random': True,
+                                          'version': '2.28',
+                                          'force': True}]})
+
+    def test_unenroll_host_payload(self):
+        """Test that unenroll_ipa_host formats payload correctly.
+        """
+        self.test_client.unenroll_host(hostname='host.foo.com')
+        self.test_client._post.assert_called_with(
+            payload={'id': 0,
+                     'params': [
+                         ['host.foo.com'],
+                         {'updatedns': True,
+                          'version': '2.28'}],
+                     'method': 'host_del'})
+
+    def test_get_hosts_results(self):
+        """Test that get_ipa_hosts parses IPA output correctly.
+        """
+        self.test_client._post = mock.MagicMock(return_value=self.FakeResponse)
+        results = self.test_client.get_hosts()
+        assert results == ['host.foo.com']
+
+    def test_add_dns_record_payload(self):
+        """Test that add_ipa_dns formats payload correctly.
+        """
+        self.test_client.add_dns_record(record_type='srvrecord',
+                                        record_name='_tcp._ssh.cellname',
+                                        record_value='10 10 10 host.foo.com')
+        self.test_client._post.assert_called_with(
+            payload={'method': 'dnsrecord_add',
+                     'params': [['foo.com', '_tcp._ssh.cellname'],
+                                {'srvrecord': '10 10 10 host.foo.com',
+                                 'version': '2.28'}],
+                     'id': 0})
+
+    def test_del_dns_record_payload(self):
+        """Test that del_dns_record formats payload correctly.
+        """
+        self.test_client.del_dns_record(record_type='srvrecord',
+                                        record_name='_tcp._ssh.cellname',
+                                        record_value='10 10 10 host.foo.com')
+        self.test_client._post.assert_called_with(
+            payload={'method': 'dnsrecord_del',
+                     'params': [['foo.com', '_tcp._ssh.cellname'],
+                                {'srvrecord': '10 10 10 host.foo.com',
+                                 'version': '2.28'}],
+                     'id': 0})
+
+    def test_get_dns_record_payload(self):
+        """Test that get_dns_record formats payload correctly.
+        """
+        # With idnsname
+        self.test_client.get_dns_record(idnsname='_tcp._ssh.cellname')
+        self.test_client._post.assert_called_with(
+            payload={'id': 0,
+                     'method': 'dnsrecord_find',
+                     'params': [['foo.com', '_tcp._ssh.cellname'],
+                                {'version': '2.28'}]})
+        # Without idnsname
+        self.test_client.get_dns_record()
+        self.test_client._post.assert_called_with(
+            payload={'id': 0,
+                     'method': 'dnsrecord_find',
+                     'params': [['foo.com'],
+                                {'version': '2.28'}]})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
DNS monitor daemon and tests complete. 

This module is intended to work in conjunction with a ZK disk mirror, using zk2fs. 
Example invocation:
python -m treadmill sproc --cell {cellname}  dnsdaemon --no-lock --proid {proid} --root /path/to/zkroot

The invoking user needs valid IPA credentials with the permission to list, add and delete DNS records until we switch to using Treadmill kerberos authentication in place of requests_kerberos in the freeIPA client. 
