### PR TITLE
Refactor how CLI parses aws indentifiers.

### DIFF
--- a/lib/python/treadmill_aws/cli/admin/aws/image.py
+++ b/lib/python/treadmill_aws/cli/admin/aws/image.py
@@ -20,7 +20,6 @@ def init():
 
     """EC2 image CLI group"""
     formatter = cli.make_formatter('aws_image')
-    image_args = {}
 
     @click.group()
     def image():
@@ -37,44 +36,50 @@ def init():
         cli.out(formatter(images))
 
     @image.command()
-    @options.make_image_opts(image_args)
-    def configure():
+    @click.option('--owner', required=False,
+                  help='Image owner, defaults to current account.')
+    @click.argument(
+        'image',
+        required=False,
+        callback=options.parse_image()
+    )
+    def configure(owner, image):
         """Configure AMI image."""
         ec2_conn = awscontext.GLOBAL.ec2
 
         # TODO: may need better switch for public/private images.
         owners = []
-        if 'owner' not in image_args:
+        if not owner:
             account = awscontext.GLOBAL.sts.get_caller_identity().get(
                 'Account'
             )
             owners.append(account)
         else:
-            owners.append(image_args['owner'])
+            owners.append(owner)
 
-        if image_args.get('tags', []):
-            image = ec2client.get_image_by_tags(
+        if image.get('tags', []):
+            image_obj = ec2client.get_image_by_tags(
                 ec2_conn,
-                image_args['tags'],
+                image['tags'],
                 owners=owners
             )
-        elif image_args.get('name'):
-            image_name = image_args['name']
-            image = ec2client.get_image_by_name(
+        elif image.get('name'):
+            image_name = image['name']
+            image_obj = ec2client.get_image_by_name(
                 ec2_conn,
                 image_name,
                 owners=owners
             )
         else:
-            image_id = image_args.get('id', metadata.image_id())
-            image = ec2client.get_image_by_id(
+            image_id = image.get('id', metadata.image_id())
+            image_obj = ec2client.get_image_by_id(
                 ec2_conn,
                 image_id
             )
 
-        cli.out(formatter(image))
+        cli.out(formatter(image_obj))
 
-#   This is a create API dummy skelleton
+    # This is a create API dummy skelleton
     @image.command(name='create')
     @click.argument('image_id')
     @cli.admin.ON_EXCEPTIONS
@@ -85,6 +90,7 @@ def init():
         cli.out(formatter(image))
 
     del _list
+    del configure
     del create
 
     return image

--- a/lib/python/treadmill_aws/cli/admin/aws/secgroup.py
+++ b/lib/python/treadmill_aws/cli/admin/aws/secgroup.py
@@ -22,7 +22,6 @@ def init():
 
     """AWS security group CLI group"""
     formatter = cli.make_formatter('aws_secgroup')
-    secgroup_args = {}
 
     @click.group()
     def secgroup():
@@ -38,19 +37,23 @@ def init():
         cli.out(formatter(secgroups))
 
     @secgroup.command()
-    @options.make_secgroup_opts(secgroup_args)
+    @click.argument(
+        'secgrp',
+        required=False,
+        callback=options.parse_security_group()
+    )
     @cli.admin.ON_EXCEPTIONS
     @treadmill_aws.cli.admin.aws.ON_AWS_EXCEPTIONS
-    def configure():
+    def configure(secgrp):
         """Configure security group."""
         ec2_conn = awscontext.GLOBAL.ec2
-        if secgroup_args.get('tags', []):
+        if secgrp.get('tags', []):
             secgroup = ec2client.get_secgroup_by_tags(
                 ec2_conn,
-                secgroup_args['tags']
+                secgrp['tags']
             )
         else:
-            secgroup_id = secgroup_args.get('id', metadata.secgroup_id())
+            secgroup_id = secgrp.get('id', metadata.secgroup_id())
             secgroup = ec2client.get_secgroup_by_id(
                 ec2_conn,
                 secgroup_id

--- a/lib/python/treadmill_aws/cli/admin/aws/subnet.py
+++ b/lib/python/treadmill_aws/cli/admin/aws/subnet.py
@@ -22,7 +22,6 @@ def init():
 
     """AWS subnet CLI group"""
     formatter = cli.make_formatter('aws_subnet')
-    subnet_args = {}
 
     @click.group()
     def subnet():
@@ -38,25 +37,29 @@ def init():
         cli.out(formatter(subnets))
 
     @subnet.command()
-    @options.make_subnet_opts(subnet_args)
+    @click.argument(
+        'subnet',
+        required=False,
+        callback=options.parse_subnet()
+    )
     @cli.admin.ON_EXCEPTIONS
     @treadmill_aws.cli.admin.aws.ON_AWS_EXCEPTIONS
-    def configure():
+    def configure(subnet):
         """Configure subnet"""
         ec2_conn = awscontext.GLOBAL.ec2
-        if subnet_args.get('tags', []):
-            subnet = ec2client.get_subnet_by_tags(
+        if subnet.get('tags', []):
+            subnet_obj = ec2client.get_subnet_by_tags(
                 ec2_conn,
-                subnet_args['tags']
+                subnet['tags']
             )
         else:
-            subnet_id = subnet_args.get('id', metadata.subnet_id())
-            subnet = ec2client.get_subnet_by_id(
+            subnet_id = subnet.get('id', metadata.subnet_id())
+            subnet_obj = ec2client.get_subnet_by_id(
                 ec2_conn,
                 subnet_id
             )
 
-        cli.out(formatter(subnet))
+        cli.out(formatter(subnet_obj))
 
     del _list
     del configure

--- a/tests/cli/options_test.py
+++ b/tests/cli/options_test.py
@@ -1,5 +1,6 @@
 """Test for click AWS options parsing."""
 
+import json
 import unittest
 
 import click
@@ -9,7 +10,7 @@ from treadmill_aws.cli import options
 
 
 class ImageOptionsTest(unittest.TestCase):
-    """Tests EC2 client interface"""
+    """Tests parsing image options"""
 
     def setUp(self):
         pass
@@ -20,42 +21,35 @@ class ImageOptionsTest(unittest.TestCase):
     def test_id_opt(self):
         """Test image options construction."""
 
-        args = dict()
-
         @click.command()
-        @options.make_image_opts(args)
-        def image():
+        @click.argument('args', callback=options.parse_image())
+        def test(args):
             """Test cli."""
-            pass
+            print(json.dumps(args))
 
         runner = CliRunner()
-        result = runner.invoke(image, ['--image-id', 'ami-1234'])
+        result = runner.invoke(test, ['ami-1234'])
+        obj = json.loads(result.output)
 
-        self.assertEqual(result.output, '')
-        self.assertEqual(args['id'], 'ami-1234')
-        self.assertFalse(args['tags'])
+        self.assertEqual(obj['id'], 'ami-1234')
+        self.assertFalse(obj['tags'])
 
-    def test_name_owner(self):
-        """Test image options construction."""
-
-        args = dict()
+    def test_image_name(self):
+        """Test image name options construction."""
 
         @click.command()
-        @options.make_image_opts(args)
-        def image():
+        @click.argument('args', callback=options.parse_image())
+        def test(args):
             """Test cli."""
-            pass
+            print(json.dumps(args))
 
         runner = CliRunner()
-        result = runner.invoke(
-            image, ['--image-name', 'xxx', '--image-owner', 'yyy']
-        )
+        result = runner.invoke(test, ['somename'])
+        obj = json.loads(result.output)
 
-        self.assertEqual(result.output, '')
-        self.assertIsNone(args.get('id'))
-        self.assertEqual(args['name'], 'xxx')
-        self.assertEqual(args['owner'], 'yyy')
-        self.assertFalse(args['tags'])
+        self.assertEqual(obj['name'], 'somename')
+        self.assertFalse(obj['tags'])
+        self.assertNotIn('id', obj)
 
 
 class SubnetOptionsTest(unittest.TestCase):
@@ -70,40 +64,34 @@ class SubnetOptionsTest(unittest.TestCase):
     def test_id_opt(self):
         """Test image options construction."""
 
-        args = dict()
-
         @click.command()
-        @options.make_subnet_opts(args)
-        def subnet():
+        @click.argument('args', callback=options.parse_subnet())
+        def test(args):
             """Test cli."""
-            pass
+            print(json.dumps(args))
 
         runner = CliRunner()
-        result = runner.invoke(subnet, ['--subnet-id', 'subnet-1234'])
+        result = runner.invoke(test, ['subnet-1234'])
+        obj = json.loads(result.output)
 
-        self.assertEqual(result.output, '')
-        self.assertEqual(args['id'], 'subnet-1234')
-        self.assertFalse(args['tags'])
+        self.assertEqual(obj['id'], 'subnet-1234')
+        self.assertFalse(obj['tags'])
 
     def test_tags(self):
         """Test image options construction."""
 
-        args = dict()
-
         @click.command()
-        @options.make_subnet_opts(args)
-        def subnet():
+        @click.argument('args', callback=options.parse_subnet())
+        def test(args):
             """Test cli."""
-            pass
+            print(json.dumps(args))
 
         runner = CliRunner()
-        result = runner.invoke(
-            subnet, ['--subnet-name', 'xxx']
-        )
+        result = runner.invoke(test, ['Name=xxx,Version=yyy'])
+        obj = json.loads(result.output)
 
-        self.assertEqual(result.output, '')
-        self.assertIsNone(args.get('id'))
-        self.assertEqual(args['tags'], {'Name': ['xxx']})
+        self.assertEqual(obj['tags']['Name'], ['xxx'])
+        self.assertEqual(obj['tags']['Version'], ['yyy'])
 
 
 class SecgroupOptionsTest(unittest.TestCase):
@@ -118,37 +106,31 @@ class SecgroupOptionsTest(unittest.TestCase):
     def test_id_opt(self):
         """Test image options construction."""
 
-        args = dict()
-
         @click.command()
-        @options.make_secgroup_opts(args)
-        def secgroup():
+        @click.argument('args', callback=options.parse_security_group())
+        def test(args):
             """Test cli."""
-            pass
+            print(json.dumps(args))
 
         runner = CliRunner()
-        result = runner.invoke(secgroup, ['--secgroup-id', 'secgroup-1234'])
+        result = runner.invoke(test, ['sg-1234'])
+        obj = json.loads(result.output)
 
-        self.assertEqual(result.output, '')
-        self.assertEqual(args['id'], 'secgroup-1234')
-        self.assertFalse(args['tags'])
+        self.assertEqual(obj['id'], 'sg-1234')
+        self.assertFalse(obj['tags'])
 
     def test_tags(self):
         """Test image options construction."""
 
-        args = dict()
-
         @click.command()
-        @options.make_secgroup_opts(args)
-        def secgroup():
+        @click.argument('args', callback=options.parse_security_group())
+        def test(args):
             """Test cli."""
-            pass
+            print(json.dumps(args))
 
         runner = CliRunner()
-        result = runner.invoke(
-            secgroup, ['--secgroup-name', 'xxx']
-        )
+        result = runner.invoke(test, ['Name=xxx,Version=yyy'])
+        obj = json.loads(result.output)
 
-        self.assertEqual(result.output, '')
-        self.assertIsNone(args.get('id'))
-        self.assertEqual(args['tags'], {'Name': ['xxx']})
+        self.assertEqual(obj['tags']['Name'], ['xxx'])
+        self.assertEqual(obj['tags']['Version'], ['yyy'])


### PR DESCRIPTION
- Support custom parsing, which all automatically detect resource id
  string based on regex, otherwise construct tags filter.