### PR TITLE
Adding fix for oddjob-mkhomedir error on instance create

### DIFF
--- a/lib/python/treadmill_aws/hostmanager.py
+++ b/lib/python/treadmill_aws/hostmanager.py
@@ -30,6 +30,8 @@ packages:
 #
 # Join domain
 runcmd:
+  - systemctl restart dbus
+  - systemctl restart systemd-logind NetworkManager
   - ipa-client-install \
   --no-krb5-offline-password \
   --enable-dns-updates \


### PR DESCRIPTION
Installing ipa_client_install includes the dbus module oddjob-mkhomedir. This module is used when IPA users first log into a new instance. 
On RHEL 7.4, the module fails to start after installation until dbus is restarted. NetworkManager cannot gracefully recover from a dbus restart, so we restart that module as well. 

