### PR TITLE
Changed logic in IPA client error handling

### DIFF
--- a/lib/python/treadmill_aws/ipaclient.py
+++ b/lib/python/treadmill_aws/ipaclient.py
@@ -109,13 +109,13 @@ class GenericError(IPAError):
 
 
 def check_response(response):
-    """Check responce does not contain errors."""
+    """Check response does not contain errors."""
     # FreeIPA returns an HTML document rather than JSON if creds not valid:
     if 'Unable to verify your Kerberos credentials' in response.text:
         raise AuthenticationError('Invalid Kerberos Credentials')
 
     response_obj = response.json()
-    if 'error' not in response_obj:
+    if not response_obj['error']:
         return
 
     err = response_obj['error']

--- a/tests/usermanager_test.py
+++ b/tests/usermanager_test.py
@@ -25,6 +25,18 @@ class UsermanagerTest(unittest.TestCase):
             'ipa-server.mydomain.x'
         self.ipaclient = ipaclient.IPAClient('certs', 'domain')
 
+    class FakeResponse(object):
+        """Fake IPA response object.
+        """
+        text = 'foo'
+        status_code = 200
+
+        def json(self=None):
+            """Fake JSON response.
+            """
+            return {'error': None,
+                    'result': {'result': {'foo': 'bar'}}}
+
     @mock.patch('subprocess.check_call',
                 return_value=mock.MagicMock())
     @mock.patch('requests.post',
@@ -32,9 +44,7 @@ class UsermanagerTest(unittest.TestCase):
     def test_create_ipa_user(self, resp_mock, subproc_mock):
         """Test create_ipa_user.
         """
-        # IPA always return 200
-        resp_mock.return_value.status_code = 200
-        resp_mock.return_value.text = 'foo'
+        resp_mock.return_value = self.FakeResponse
 
         result = usermanager.create_ipa_user(
             ipa_client=self.ipaclient,
@@ -58,8 +68,7 @@ class UsermanagerTest(unittest.TestCase):
     def test_create_ipa_user_no_creds(self, resp_mock, subproc_mock):
         """Test create_ipa_user with invalid creds.
         """
-        # IPA always return 200
-        resp_mock.return_value.status_code = 200
+        resp_mock.return_value = self.FakeResponse
         resp_mock.return_value.text = \
             'Unable to verify your Kerberos credentials'
 


### PR DESCRIPTION
The IPA client response always contains the key 'error', set by default to None. 
This patch changes the function logic to check the value of the 'error' key instead of checking for the presence of the 'error' key. 