### PR TITLE
Removing IPA search limit for API calls

### DIFF
--- a/lib/python/treadmill_aws/ipaclient.py
+++ b/lib/python/treadmill_aws/ipaclient.py
@@ -115,6 +115,12 @@ def check_response(response):
         raise AuthenticationError('Invalid Kerberos Credentials')
 
     response_obj = response.json()
+
+    # Only search results contain 'truncated' key:
+    if 'truncated' in response_obj['result']:
+        if response_obj['result']['truncated']:
+            raise IPAError('IPA results truncated.')
+
     if not response_obj['error']:
         return
 
@@ -194,7 +200,8 @@ class IPAClient():
         """
         payload = {'method': 'host_find',
                    'params': [[pattern],
-                              {'version': _API_VERSION}],
+                              {'version': _API_VERSION,
+                               'sizelimit': 0}],
                    'id': 0}
         resp = self._post(payload=payload).json()
 
@@ -229,12 +236,14 @@ class IPAClient():
         if idnsname:
             payload = {'method': 'dnsrecord_find',
                        'params': [[self.domain, idnsname],
-                                  {'version': _API_VERSION}],
+                                  {'version': _API_VERSION,
+                                   'sizelimit': 0}],
                        'id': 0}
         else:
             payload = {'method': 'dnsrecord_find',
                        'params': [[self.domain],
-                                  {'version': _API_VERSION}],
+                                  {'version': _API_VERSION,
+                                   'sizelimit': 0}],
                        'id': 0}
         return self._post(payload=payload).json()
 
@@ -270,12 +279,14 @@ class IPAClient():
         if pattern:
             payload = {'method': 'user_find',
                        'params': [[pattern],
-                                  {'version': _API_VERSION}],
+                                  {'version': _API_VERSION,
+                                   'sizelimit': 0}],
                        'id': 0}
         else:
             payload = {'method': 'user_find',
                        'params': [[],
-                                  {'version': _API_VERSION}],
+                                  {'version': _API_VERSION,
+                                   'sizelimit': 0}],
                        'id': 0}
         return self._post(payload=payload).json()['result']['result']
 

--- a/tests/ipaclient_test.py
+++ b/tests/ipaclient_test.py
@@ -249,14 +249,16 @@ class IPAClientTest(unittest.TestCase):
             payload={'id': 0,
                      'method': 'dnsrecord_find',
                      'params': [['foo.com', '_tcp._ssh.cellname'],
-                                {'version': '2.28'}]})
+                                {'version': '2.28',
+                                 'sizelimit': 0}]})
         # Without idnsname
         self.test_client.get_dns_record()
         self.test_client._post.assert_called_with(
             payload={'id': 0,
                      'method': 'dnsrecord_find',
                      'params': [['foo.com'],
-                                {'version': '2.28'}]})
+                                {'version': '2.28',
+                                 'sizelimit': 0}]})
 
     def test_add_user(self):
         """ Test that add_user formats payload correctly """
@@ -294,7 +296,8 @@ class IPAClientTest(unittest.TestCase):
             payload={'id': 0,
                      'method': 'user_find',
                      'params': [['foo'],
-                                {'version': '2.28'}]})
+                                {'version': '2.28',
+                                 'sizelimit': 0}]})
 
         # Without pattern
         self.test_client.list_users()
@@ -302,7 +305,8 @@ class IPAClientTest(unittest.TestCase):
             payload={'id': 0,
                      'method': 'user_find',
                      'params': [[],
-                                {'version': '2.28'}]})
+                                {'version': '2.28',
+                                 'sizelimit': 0}]})
 
     def test_show_user(self):
         """ Test that show_user formats payload correctly """

--- a/tests/usermanager_test.py
+++ b/tests/usermanager_test.py
@@ -101,6 +101,7 @@ class UsermanagerTest(unittest.TestCase):
                 'code': 4002,
                 'message': 'error',
             },
+            'result': []
         }
         resp_mock.return_value.json = json_mock
 


### PR DESCRIPTION
I've added the searchlimit: 0 (infinite) parameter to the host_find, dnsrecord_find, and user_find functions to prevent the IPA API from truncating results. 