### PR TITLE
Correcting CLI behaviour

### DIFF
--- a/lib/python/treadmill_aws/cli/admin/aws/instance.py
+++ b/lib/python/treadmill_aws/cli/admin/aws/instance.py
@@ -98,8 +98,8 @@ def init():
     @click.option(
         '--disk-size',
         required=True,
-        default=10,
-        help='Root parition size',
+        default='10G',
+        help='Root parition size, e.g. 100G',
         callback=aws_cli.convert_disk_size_to_int
     )
     @treadmill_aws.cli.admin.aws.ON_AWS_EXCEPTIONS


### PR DESCRIPTION
With the argument **default=10**, Click expects an integer and exits with an error if a string is passed instead. 
Changed the default argument to reflect the intent of the callback function & clarified the help text.