### PR TITLE
Adding package name to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ def _read_requires(filename):
 
 
 setuptools.setup(
+    name='Treadmill_AWS',
     version='1.0',
     install_requires=_read_requires('requirements.txt'),
     extras_require={


### PR DESCRIPTION
Without this line, pip wheel creates the new wheel with the name UNKNOWN. 