### PR TITLE
Fixes for AWS zookeeper.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include lib/python/treadmill_aws/bootstrap/node/aws.linux *
+recursive-include lib/python/treadmill_aws/bootstrap/master/aws.linux *

--- a/lib/python/treadmill_aws/bootstrap/master/aws.linux/treadmill/env/TREADMILL_ZOOKEEPER
+++ b/lib/python/treadmill_aws/bootstrap/master/aws.linux/treadmill/env/TREADMILL_ZOOKEEPER
@@ -1,0 +1,1 @@
+zookeeper.sasl://zookeeper@{% for master in masters %}{{ master['hostname'] }}:{{ master['zk-client-port'] }}{{ "," if not loop.last }}{% endfor %}/treadmill/{{ _id }}

--- a/lib/python/treadmill_aws/bootstrap/master/aws.py
+++ b/lib/python/treadmill_aws/bootstrap/master/aws.py
@@ -1,0 +1,18 @@
+"""AWS defaults."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+# Defaults.
+
+from .. import aws_aliases as aliases
+
+
+DEFAULTS = {
+    'treadmill_host_ticket': '/treadmill/spool/krb5cc_host',
+    'broken_nodes_percent': '5%',
+}
+
+ALIASES = aliases.ALIASES

--- a/lib/python/treadmill_aws/bootstrap/node/aws.linux/env/TREADMILL_ZOOKEEPER
+++ b/lib/python/treadmill_aws/bootstrap/node/aws.linux/env/TREADMILL_ZOOKEEPER
@@ -1,0 +1,1 @@
+zookeeper.sasl://zookeeper@{% for master in masters %}{{ master['hostname'] }}:{{ master['zk-client-port'] }}{{ "," if not loop.last }}{% endfor %}/treadmill/{{ cell }}

--- a/lib/python/treadmill_aws/plugins/zookeeper.py
+++ b/lib/python/treadmill_aws/plugins/zookeeper.py
@@ -13,7 +13,10 @@ import kazoo.security
 
 from treadmill import zkutils
 
-_ROLES = ['servers', 'admins', 'readers']
+_ROLES = {
+    'admin': 'admins',
+}
+
 _DEFAULT_ZK_SERVICE = 'zookeeper'
 
 _LOGGER = logging.getLogger('__name__')
@@ -65,10 +68,10 @@ class SASLZkClient(zkutils.ZkClient):
         Roles are sourced from our LDAP lookup plugin, in the format
         'role/<role>.
         """
-        assert role in _ROLES
-
+        credential = 'role/{0}'.format(_ROLES.get(role, role))
         return kazoo.security.make_acl(
-            scheme='sasl', credential='role/{0}'.format(role),
+            scheme='sasl',
+            credential=credential,
             read='r' in perm,
             write='w' in perm,
             create='c' in perm,


### PR DESCRIPTION
- Properly configure zk connection string to use sasl protocol.
- Handle admin/admins role when constructing user acl.
- Added master bootstrap profile.