### PR TITLE
Temprorary disable sasl for zk.

### DIFF
--- a/lib/python/treadmill_aws/bootstrap/master/aws.linux/treadmill/env/TREADMILL_ZOOKEEPER
+++ b/lib/python/treadmill_aws/bootstrap/master/aws.linux/treadmill/env/TREADMILL_ZOOKEEPER
@@ -1,1 +1,1 @@
-zookeeper.sasl://zookeeper@{% for master in masters %}{{ master['hostname'] }}:{{ master['zk-client-port'] }}{{ "," if not loop.last }}{% endfor %}/treadmill/{{ _id }}
+zookeeper://{% for master in masters %}{{ master['hostname'] }}:{{ master['zk-client-port'] }}{{ "," if not loop.last }}{% endfor %}/treadmill/{{ _id }}

--- a/lib/python/treadmill_aws/bootstrap/node/aws.linux/env/TREADMILL_ZOOKEEPER
+++ b/lib/python/treadmill_aws/bootstrap/node/aws.linux/env/TREADMILL_ZOOKEEPER
@@ -1,1 +1,1 @@
-zookeeper.sasl://zookeeper@{% for master in masters %}{{ master['hostname'] }}:{{ master['zk-client-port'] }}{{ "," if not loop.last }}{% endfor %}/treadmill/{{ cell }}
+zookeeper://{% for master in masters %}{{ master['hostname'] }}:{{ master['zk-client-port'] }}{{ "," if not loop.last }}{% endfor %}/treadmill/{{ cell }}

--- a/lib/python/treadmill_aws/bootstrap/node/aws.linux/init/kernel_watchdog.yml
+++ b/lib/python/treadmill_aws/bootstrap/node/aws.linux/init/kernel_watchdog.yml
@@ -1,0 +1,9 @@
+command: |
+  exec /bin/sleep inf
+environ_dir: "{{ dir }}/env"
+call_before_finish: "{{ dir }}/bin/stop_watchdog.sh"
+monitor_policy:
+  limit: 1
+  interval: 60
+  tombstone:
+    path: "{{ dir }}/tombstones/init"


### PR DESCRIPTION
- Zookeeper SASL plugin does not seem to work properly, temporary
  disable sasl in connection string.
- Disable kernel watchdog.