### PR TITLE
Add boot configuration scripts.

### DIFF
--- a/lib/python/treadmill_aws/bootstrap/node/aws.linux/bin/parts/50_configure_keytabs.sh
+++ b/lib/python/treadmill_aws/bootstrap/node/aws.linux/bin/parts/50_configure_keytabs.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Configure host and HTTP keytabs.
+
+KT_SPLIT="{{ _alias.kt_split }}"
+LS="{{ _alias.ls }}"
+MKDIR="{{ _alias.mkdir }}"
+
+function fetch_all_treadmill_vip_keytabs {
+
+    # TODO: implement fetching keytabs for the VIPs
+    ${MKDIR} -vp {{ dir }}/spool/keytabs
+    ${KT_SPLIT} \
+        -d"{{ dir }}/spool/keytabs" \
+        "/etc/krb5.keytab"
+
+    ${LS} -al "{{ dir }}/spool/keytabs"
+}
+
+fetch_all_treadmill_vip_keytabs

--- a/lib/python/treadmill_aws/bootstrap/node/aws.linux/bin/parts/60_ld_so_preload.sh
+++ b/lib/python/treadmill_aws/bootstrap/node/aws.linux/bin/parts/60_ld_so_preload.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Ensure that /etc/ld.so.preload exists.
+#
+# TODO: temp workaround, until the core code is fixed to handle this condition
+#       gracefully.
+
+
+TOUCH="{{ _alias.touch }}"
+$TOUCH /etc/ld.so.preload


### PR DESCRIPTION
- Prepare host keytab file in the treadmill/spool/keytab directory.
- Ensure that /etc/ld.so.preload exists, as temp workaround until the
  code to handle file absense gracefully.