### PR TITLE
Add "master" apps to admin cell bootstrap.

### DIFF
--- a/lib/python/treadmill_aws/cli/admin/templates/appmonitor
+++ b/lib/python/treadmill_aws/cli/admin/templates/appmonitor
@@ -1,0 +1,47 @@
+---
+memory: 3G
+cpu: 50%
+disk: 1G
+services:
+- name: monitor
+  command: |
+    unset PYTHONPATH;
+    mkdir -p /var/tmp/treadmill/alerts
+    exec /opt/treadmill/bin/treadmill sproc appmonitor \
+        --api http+unix://%2Ftmp%2Fcellapi.sock \
+        --approot /var/tmp/treadmill
+  restart:
+    limit: 5
+    interval: 60
+- name: alerts-monitor
+  command: |
+    unset PYTHONPATH;
+    mkdir -p /var/tmp/treadmill/alerts
+    exec /opt/treadmill/bin/treadmill sproc \
+        alert-monitor --approot /var/tmp/treadmill
+  restart:
+    limit: 5
+    interval: 60
+- name: cellapi
+  command: |
+    unset PYTHONPATH;
+    echo "plugins: [aws-proid-env]" > /tmp/instance.cfg.yml
+    rm -f /tmp/cellapi.sock
+    exec /opt/treadmill/bin/treadmill sproc restapi \
+      -s /tmp/cellapi.sock \
+      --title 'Treadmill_Cell_API' \
+      -m instance,app-monitor \
+      --config instance /tmp/instance.cfg.yml \
+      --cors-origin='.*' \
+      -a trusted
+  restart:
+    limit: 5
+    interval: 60
+endpoints: []
+environ:
+- name: KRB5CCNAME
+  value: /var/spool/tickets/{{ proid }}
+affinity_limits:
+  server: 1
+tickets:
+- {{ proid }}@{{ krb_realm }}

--- a/lib/python/treadmill_aws/cli/admin/templates/cellapi
+++ b/lib/python/treadmill_aws/cli/admin/templates/cellapi
@@ -29,3 +29,5 @@ environ:
   value: /var/spool/tickets/{{ proid }}
 affinity_limits:
   server: 1
+tickets:
+- {{ proid }}@{{ krb_realm }}

--- a/lib/python/treadmill_aws/cli/admin/templates/cellsync
+++ b/lib/python/treadmill_aws/cli/admin/templates/cellsync
@@ -1,0 +1,20 @@
+---
+memory: 1G
+cpu: 50%
+disk: 1G
+services:
+- command: |
+    unset PYTHONPATH;
+    exec /opt/treadmill/bin/treadmill sproc cellsync
+  name: cellsync
+  restart:
+    limit: 5
+    interval: 60
+endpoints: []
+environ:
+- name: KRB5CCNAME
+  value: /var/spool/tickets/{{ proid }}
+affinity_limits:
+  server: 1
+tickets:
+- {{ proid }}@{{ krb_realm }}

--- a/lib/python/treadmill_aws/cli/admin/templates/monitors
+++ b/lib/python/treadmill_aws/cli/admin/templates/monitors
@@ -4,3 +4,7 @@
 {{ proid }}.cellapi.{{ cell }}: 1
 {{ proid }}.wsapi.{{ cell }}: 1
 {{ proid }}.stateapi.{{ cell }}: 1
+{{ proid }}.scheduler.{{ cell }}: 3
+{{ proid }}.appmonitor.{{ cell }}: 3
+{{ proid }}.trace-cleanup.{{ cell }}: 3
+{{ proid }}.cellsync.{{ cell }}: 3

--- a/lib/python/treadmill_aws/cli/admin/templates/scheduler
+++ b/lib/python/treadmill_aws/cli/admin/templates/scheduler
@@ -1,0 +1,31 @@
+---
+memory: 3G
+cpu: 50%
+disk: 1G
+services:
+- name: scheduler
+  command: |
+    unset PYTHONPATH;
+    mkdir -p /var/tmp/treadmill/appevents
+    exec /opt/treadmill/bin/treadmill sproc scheduler \
+        --events-dir /var/tmp/treadmill/appevents
+  restart:
+    limit: 5
+    interval: 60
+- name: appevents
+  command: |
+    unset PYTHONPATH;
+    mkdir -p /var/tmp/treadmill/appevents
+    exec /opt/treadmill/bin/treadmill sproc \
+        appevents /var/tmp/treadmill/appevents
+  restart:
+    limit: 5
+    interval: 60
+endpoints: []
+environ:
+- name: KRB5CCNAME
+  value: /var/spool/tickets/{{ proid }}
+affinity_limits:
+  server: 1
+tickets:
+- {{ proid }}@{{ krb_realm }}

--- a/lib/python/treadmill_aws/cli/admin/templates/stateapi
+++ b/lib/python/treadmill_aws/cli/admin/templates/stateapi
@@ -27,3 +27,5 @@ environ:
   value: /var/spool/tickets/{{ proid }}
 affinity_limits:
   server: 1
+tickets:
+- {{ proid }}@{{ krb_realm }}

--- a/lib/python/treadmill_aws/cli/admin/templates/trace-cleanup
+++ b/lib/python/treadmill_aws/cli/admin/templates/trace-cleanup
@@ -1,0 +1,20 @@
+---
+memory: 1G
+cpu: 50%
+disk: 1G
+services:
+- command: |
+    unset PYTHONPATH;
+    exec /opt/treadmill/bin/treadmill sproc trace cleanup
+  name: cellsync
+  restart:
+    limit: 5
+    interval: 60
+endpoints: []
+environ:
+- name: KRB5CCNAME
+  value: /var/spool/tickets/{{ proid }}
+affinity_limits:
+  server: 1
+tickets:
+- {{ proid }}@{{ krb_realm }}

--- a/lib/python/treadmill_aws/cli/admin/templates/wsapi
+++ b/lib/python/treadmill_aws/cli/admin/templates/wsapi
@@ -40,3 +40,5 @@ environ:
   value: /var/spool/tickets/{{ proid }}
 affinity_limits:
   server: 1
+tickets:
+- {{ proid }}@{{ krb_realm }}


### PR DESCRIPTION
- admin cell configure/restart apps/monitors will inclnude scheduler
  among other system apps. No need to run separate treadmill master
  anymore.