### PR TITLE
Escaping values in generated YAML

### DIFF
--- a/lib/python/treadmill_aws/hostmanager.py
+++ b/lib/python/treadmill_aws/hostmanager.py
@@ -18,7 +18,7 @@ def render_manifest(key_value_pairs):
     """ Stub function to supply instance user_data during testing. """
 
     return "#cloud-config\n" + yaml.dump(
-        key_value_pairs, default_flow_style=False)
+        key_value_pairs, default_flow_style=False, default_style='\'')
 
 
 def generate_hostname(domain, image):

--- a/tests/hostmanager_test.py
+++ b/tests/hostmanager_test.py
@@ -17,3 +17,11 @@ class HostmanagerTest(unittest.TestCase):
               'Tags': [{'Key': 'Name', 'Value': 'host.foo.com'},
                        {'Key': 'Role', 'Value': 'foo'}]}]
         )
+
+    def test_render_manifest(self):
+        """Test that YAML is rendered correctly."""
+        self.assertEqual(
+            hostmanager.render_manifest({'otp': 'abc123',
+                                         'hostname': 'host.foo.com'}),
+            "#cloud-config\n'hostname': 'host.foo.com'\n'otp': 'abc123'\n"
+        )


### PR DESCRIPTION
This change wraps the YAML passed to AWS in single quotes. This is important due to special characters and globs embedded in the OTP.

otp: 123456 
to 
'otp': '123456'