### PR TITLE
sshd pam config - replaces pam_oddjob_mkhomedir.so with pam_mkhomedir.so

### DIFF
--- a/lib/python/treadmill_aws/bootstrap/node/aws.linux/etc/pam.d/sshd
+++ b/lib/python/treadmill_aws/bootstrap/node/aws.linux/etc/pam.d/sshd
@@ -1,0 +1,24 @@
+#%PAM-1.0
+auth	   required	pam_sepermit.so
+auth       substack     password-auth
+auth       include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-auth      optional     pam_reauthorize.so prepare
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     optional      pam_mkhomedir.so umask=0077
+session     required      pam_unix.so
+session     optional      pam_sss.so
+session    include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-session   optional     pam_reauthorize.so prepare


### PR DESCRIPTION
New sshd pam config for containers.

This replaces config mounted from underlying host. If pulls in session stack from "password-auth" and replaces pam_oddjob_mkhomedir.so with pam_mkhomedir.so.

pam_oddjob_mkhomedir.so has dependency on dbus socket which it uses to ask sssd to create home directory. This is wrong for many reason (having dbus socket visible in container represents an IPC path to the underlying host, not to mention, homedir would be by sssd on the underlying host.

pam_mkhomedir.so causes homedir to be created in the container itself and has no dependency on dbus or sssd.