### PR TITLE
Implemented krb5keytab support.

### DIFF
--- a/entry_points.txt
+++ b/entry_points.txt
@@ -15,11 +15,12 @@ aws-image = treadmill_aws.api.image
 
 [treadmill.cli]
 aws = treadmill_aws.cli.aws
+krb5keytab = treadmill_aws.cli.krb5keytab
 
 [treadmill.cli.admin]
 aws = treadmill_aws.cli.admin.aws
 cell = treadmill_aws.cli.admin.cell
-
+krb5keytab = treadmill_aws.cli.admin.krb5keytab
 
 [treadmill_aws.cli.aws]
 image = treadmill_aws.cli.aws.image
@@ -49,6 +50,7 @@ awscredential = treadmill_aws.sproc.awscredential
 app-dns-ipa = treadmill_aws.sproc.app_dns
 ipakeytab = treadmill_aws.sproc.ipakeytab
 ipa525 = treadmill_aws.sproc.ipa525
+krb5keytab-proxy = treadmill_aws.sproc.krb5keytabproxy
 
 [treadmill.bootstrap]
 aliases.aws = treadmill_aws.bootstrap.aws_aliases

--- a/lib/python/treadmill_aws/cli/admin/krb5keytab.py
+++ b/lib/python/treadmill_aws/cli/admin/krb5keytab.py
@@ -1,0 +1,151 @@
+"""Request user or proid keytabs, directly contacting krb5keytab server.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import json
+import os
+import pwd
+import base64
+
+import click
+import dns.resolver
+
+import treadmill
+from treadmill import sysinfo
+from treadmill import fs
+from treadmill import gssapiprotocol
+
+from treadmill_aws import awscontext
+
+_LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_KEYTAB_DIR = '/var/spool/keytabs'
+
+
+def _request_keytab(server, port, principal):
+    """Request keytab from keytab server."""
+    client = gssapiprotocol.GSSAPILineClient(
+        server, port, "host@%s" % server
+    )
+    if not client.connect():
+        _LOGGER.warning(
+            'Failed to connect/authenticate to %s:%s',
+            server, port
+        )
+        return None
+
+    client.write(principal.encode("utf-8"))
+    line = client.read().decode("utf-8")
+    client.disconnect()
+
+    response = json.loads(line)
+    if response['status'] == 'failure':
+        # TODO: need better output for error messages.
+        _LOGGER.error(
+            'Error requesting keytab: %s',
+            json.dumps(response, indent=4, sort_keys=True)
+        )
+        return None
+
+    if response['status'] == 'success':
+        keytab_entries = base64.standard_b64decode(
+            response['result']['keytab_entries']
+        )
+
+        return keytab_entries
+
+    raise Exception(
+        'Unexpected error: %s' %
+        json.dumps(response, indent=4, sort_keys=True)
+    )
+
+
+def _write_keytab(keytab_entries, keytab, owner):
+    """Write keytab file."""
+
+    try:
+        pwnam = pwd.getpwnam(owner)
+    except KeyError:
+        _LOGGER.error('Invalid user: %s', owner)
+        return
+
+    fs.write_safe(
+        keytab,
+        lambda f: f.write(keytab_entries),
+        owner=(pwnam.pw_uid, pwnam.pw_gid)
+    )
+
+
+def init():
+    """Admin Cell CLI module"""
+
+    @click.command()
+    @click.option('--krb5keytab-server',
+                  required=False,
+                  metavar='HOST:PORT',
+                  multiple=True,
+                  help='Address of ipakeytab server.')
+    @click.option('--principal',
+                  required=False,
+                  help='Requsted principal ($user or $user/$hostname).')
+    @click.option('--keytab',
+                  required=False,
+                  help='Destination keytab file.')
+    @click.option('--owner',
+                  required=False,
+                  help='chown to specifed Unix ID.')
+    def krb5keytab(krb5keytab_server, principal, keytab, owner):
+        """krb5keytab client"""
+        username = pwd.getpwuid(os.getuid())[0]
+        hostname = sysinfo.hostname()
+
+        treadmill.logging.set_log_level(logging.INFO)
+
+        if not principal:
+            principal = '{}/{}'.format(username, hostname)
+
+        if not owner:
+            owner = username
+
+        if not keytab:
+            keytab = os.path.join(_DEFAULT_KEYTAB_DIR, owner)
+
+        if not krb5keytab_server:
+            krb5keytab_server = []
+            domain = awscontext.GLOBAL.ipa_domain
+            try:
+                srvrecs = dns.resolver.query(
+                    '_krb5keytab._tcp.{}'.format(domain), 'SRV'
+                )
+            except dns.resolver.NXDOMAIN:
+                srvrecs = []
+            for result in srvrecs:
+                _, _, port, server = result.to_text().split()
+                krb5keytab_server.append('{}:{}'.format(server, port))
+
+        if not krb5keytab_server:
+            treadmill.cli.bad_exit(
+                'Configuration/usage error: '
+                '--krb5keytab-server not specified/DNS not configured'
+                ' - exiting.'
+            )
+
+        _LOGGER.info('Principal   : %s', principal)
+        _LOGGER.info('Keytab      : %s', keytab)
+        _LOGGER.info('Owner       : %s', owner)
+        kt_entries = None
+
+        for endpoint in krb5keytab_server:
+            _LOGGER.info('Connecting to %s', endpoint)
+            server, port = endpoint.split(':')
+            kt_entries = _request_keytab(server, int(port), principal)
+            if kt_entries:
+                _write_keytab(kt_entries, keytab, owner)
+                return
+
+    return krb5keytab

--- a/lib/python/treadmill_aws/cli/krb5keytab.py
+++ b/lib/python/treadmill_aws/cli/krb5keytab.py
@@ -1,0 +1,78 @@
+"""Request proid keytabs, directly contacting krb5keytab server.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import json
+import base64
+
+import click
+
+from treadmill import cli
+from treadmill import fs
+from treadmill import peercredprotocol
+
+
+_LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_KEYTAB_DIR = '/var/spool/keytabs'
+
+_DEFAULT_SOCK_PATH = '/var/run/krb5keytab.sock'
+
+
+def init():
+    """Admin Cell CLI module"""
+
+    @click.command()
+    @click.option('--keytab',
+                  required=False,
+                  help='Keytab file.')
+    @click.option('--sock-path',
+                  required=False,
+                  help='Path to krb5keytab socket.')
+    def krb5keytab(keytab, sock_path):
+        """The client utility to get krb5keytab from the local proxy."""
+        if not sock_path:
+            sock_path = _DEFAULT_SOCK_PATH
+
+        client = peercredprotocol.PeerCredLineClient(sock_path)
+        try:
+            client.connect()
+            request = {}
+            if keytab:
+                # If we write keytab ourselvs, do not ask server to write the
+                # file.
+                request['keytab'] = False
+
+            client.write(json.dumps(request).encode('utf8'))
+            reply = client.read()
+            if not reply:
+                cli.bad_exit('Connection closed.')
+
+            response = json.loads(reply.decode())
+            if response.get('status') != 'success':
+                cli.bad_exit(response.get('why', 'Unknown error'))
+
+            if keytab:
+                keytab_entries = base64.standard_b64decode(
+                    response['result']['keytab_entries']
+                )
+                _LOGGER.info('Writing keytab: %s', keytab)
+                fs.write_safe(
+                    keytab,
+                    lambda f: f.write(keytab_entries),
+                )
+
+        except FileNotFoundError:
+            cli.bad_exit(
+                'Failed connecting to %s, krb5keytab proxy is not running.',
+                sock_path
+            )
+        finally:
+            client.disconnect()
+
+    return krb5keytab

--- a/lib/python/treadmill_aws/sproc/krb5keytabproxy.py
+++ b/lib/python/treadmill_aws/sproc/krb5keytabproxy.py
@@ -1,0 +1,220 @@
+"""Local krb5-keytab proxy."""
+
+import base64
+import json
+import logging
+import os
+import sys
+
+import click
+import dns.resolver
+
+from twisted.internet import reactor
+from twisted.internet import protocol
+from twisted.internet import task
+
+from treadmill import gssapiprotocol
+from treadmill import fs
+from treadmill import sysinfo
+from treadmill import subproc
+from treadmill import peercredprotocol
+
+from treadmill_aws import awscontext
+
+
+_LOGGER = logging.getLogger(__name__)
+
+# Refresh tickets every 2 hours
+_HOST_CREDS_REFRESH_INTERVAL = 60 * 60 * 2
+
+_DEFAULT_SOCK_PATH = '/var/run/krb5keytab.sock'
+
+_DEFAULT_KEYTAB_DIR = '/var/spool/keytabs'
+
+
+def _request_keytab(server, port, principal):
+    """Request keytab from keytab server."""
+    client = gssapiprotocol.GSSAPILineClient(
+        server, port, "host@%s" % server
+    )
+
+    client.connect()
+    client.write(principal.encode("utf-8"))
+    line = client.read().decode("utf-8")
+    client.disconnect()
+
+    return json.loads(line)
+
+
+class Krb5KeytabProxy(peercredprotocol.PeerCredLineServer):
+    """Proxy krb5keytab requests to krb5keytab server."""
+
+    def __init__(self, hostname, domain, krb5keytab_servers, keytab_dir):
+        self.hostname = hostname
+        self.domain = domain
+        self.krb5keytab_servers = krb5keytab_servers
+        self.keytab_dir = keytab_dir
+        super(__class__, self).__init__()
+
+    def _handle_error(self, msg, err):
+        """Handle error, return reason back to the client."""
+        error = {
+            'status': 'failure',
+            'why': '{} - {}'.format(msg, str(err)),
+        }
+        self.write(json.dumps(error).encode('utf8'))
+
+    def _handle(self, response):
+        """Hanlde krb5keytab response.
+        """
+        try:
+            _LOGGER.info('Got krb5keytab response: %s', response['status'])
+            if response['status'] == 'success':
+                self.write(json.dumps(response).encode('utf8'))
+            else:
+                # TODO: need better output for error messages.
+                _LOGGER.error(
+                    'Error requesting keytab: %s',
+                    json.dumps(response, indent=4, sort_keys=True)
+                )
+                self.write(json.dumps(response).encode('utf8'))
+
+        except Exception as err:  # pylint: disable=W0703
+            self._handle_error('Unexpected error', err)
+            raise err
+        finally:
+            self.transport.loseConnection()
+
+    def _write_keytab(self, response):
+        """Safely writes the keytab to disk."""
+        keytab = os.path.join(self.keytab_dir, self.peer())
+        keytab_entries = base64.standard_b64decode(
+            response['result']['keytab_entries']
+        )
+        _LOGGER.info('Writing keytab: %s', keytab)
+        fs.write_safe(
+            keytab,
+            lambda f: f.write(keytab_entries),
+            owner=(self.uid, self.gid)
+        )
+
+    def got_line(self, data):
+        """Process keytab request.
+
+        data containes either target filename, in which case it will write the
+        resulting keytab to the file, or "-", so that keytab will be returned
+        to the client in the reply.
+        """
+        request = json.loads(data.decode())
+        keytab = request.get('keytab')
+
+        username = self.peer()
+        principal = '{}/{}'.format(username, self.hostname)
+        _LOGGER.info('Requesting keytab: %s', principal)
+
+        endpoints = list(self.krb5keytab_servers)
+        if not endpoints:
+            # Try to get servers on each request, as srv records can change
+            # during the run.
+            try:
+                srvrecs = dns.resolver.query(
+                    '_krb5keytab._tcp.{}'.format(self.domain), 'SRV'
+                )
+            except dns.resolver.NXDOMAIN:
+                srvrecs = []
+            for result in srvrecs:
+                _, _, port, server = result.to_text().split()
+                endpoints.append('{}:{}'.format(server, port))
+
+        last_err = None
+        for endpoint in endpoints:
+            _LOGGER.info('Connecting to %s', endpoint)
+            server, port = endpoint.split(':')
+            try:
+                response = _request_keytab(server, int(port), principal)
+                if response:
+                    self._handle(response)
+                    if keytab:
+                        # Write keytab to the disk.
+                        self._write_keytab(response)
+                    break
+            except ConnectionError as conn_err:
+                last_err = conn_err
+                _LOGGER.error(
+                    'Error requesting keytab from %s - %s',
+                    endpoint,
+                    str(conn_err)
+                )
+
+        if last_err:
+            self._handle_error('Error requesting keytabs', last_err)
+
+
+class Krb5KeytabProxyFactory(protocol.Factory):
+    """Krb5KeytabProxy protocol factory."""
+
+    def __init__(self, krb5keytab_servers, keytab_dir):
+        self.hostname = sysinfo.hostname()
+        self.keytab_dir = keytab_dir
+        self.domain = awscontext.GLOBAL.ipa_domain
+
+        self.krb5keytab_servers = krb5keytab_servers
+
+        super(__class__, self).__init__()
+
+    def buildProtocol(self, addr):  # pylint: disable=C0103
+        return Krb5KeytabProxy(
+            hostname=self.hostname,
+            domain=self.domain,
+            krb5keytab_servers=self.krb5keytab_servers,
+            keytab_dir=self.keytab_dir
+        )
+
+
+def init():
+    """Top level command handler."""
+
+    @click.command()
+    @click.option('--krb5keytab-server',
+                  required=False,
+                  metavar='HOST:PORT',
+                  multiple=True,
+                  help='Address of ipakeytab server.')
+    @click.option('--sock-path',
+                  required=False,
+                  help='Path to UDS socket server.')
+    @click.option('--keytab-dir',
+                  required=False,
+                  help='Directory to store keytabs.')
+    def krb5keytabproxy(sock_path, krb5keytab_server, keytab_dir):
+        """Run krb5keytab proxy server."""
+        if not sock_path:
+            sock_path = _DEFAULT_SOCK_PATH
+
+        if not keytab_dir:
+            keytab_dir = _DEFAULT_KEYTAB_DIR
+
+        # Check the keytab dir is owned by root.
+        stat = os.stat(keytab_dir)
+        if stat.st_uid != 0 or stat.st_gid != 0:
+            _LOGGER.warning(
+                'Keytab directory must be owned by root: %s', keytab_dir
+            )
+            sys.exit(-1)
+
+        fs.rm_safe(sock_path)
+
+        os.environ['KRB5CCNAME'] = 'FILE:/tmp/krb5cc_host_krb5keytab_proxy'
+
+        def _refresh_krbcc():
+            """Refresh host credentials."""
+            subproc.check_call(['kinit', '-k'])
+
+        task.LoopingCall(_refresh_krbcc).start(_HOST_CREDS_REFRESH_INTERVAL)
+        reactor.listenUNIX(
+            sock_path,
+            Krb5KeytabProxyFactory(list(krb5keytab_server), keytab_dir)
+        )
+        reactor.run()
+
+    return krb5keytabproxy

--- a/tests/sproc/krb5keytabproxy_test.py
+++ b/tests/sproc/krb5keytabproxy_test.py
@@ -1,0 +1,86 @@
+"""Test for krb5keytabproxy."""
+
+import base64
+import json
+import unittest
+
+import mock
+
+import treadmill
+from treadmill_aws.sproc import krb5keytabproxy
+
+
+# pylint: disable=protected-access
+
+class Krb5keytabProxyTest(unittest.TestCase):
+    """Tests krb5keytab proxy."""
+
+    @mock.patch('treadmill.gssapiprotocol.GSSAPILineClient.connect',
+                mock.Mock(return_value=mock.MagicMock()))
+    @mock.patch('treadmill.gssapiprotocol.GSSAPILineClient.disconnect',
+                mock.Mock(return_value=mock.MagicMock()))
+    @mock.patch('treadmill.gssapiprotocol.GSSAPILineClient.write',
+                mock.Mock(return_value=mock.MagicMock()))
+    @mock.patch('treadmill.gssapiprotocol.GSSAPILineClient.read',
+                mock.Mock(return_value=json.dumps({
+                    'status': 'success',
+                    'result': {
+                        'keytab_entries': base64.encodebytes(b'abc').decode()
+                    }
+                }).encode('utf8')))
+    @mock.patch('treadmill.fs.write_safe', mock.Mock())
+    def test_request_keytab(self):
+        """Tests client request."""
+        proxy = krb5keytabproxy.Krb5KeytabProxy(
+            'my-hostname.my-domain',
+            'my-ipa.domain',
+            ['kt-srv1:1234', 'kt-srv2:1234'],
+            '/key/tab/dir'
+        )
+        proxy.uid = 1
+        proxy.gid = 2
+        proxy.username = 'xxx'
+        proxy.transport = mock.MagicMock()
+
+        encoded = json.dumps({'keytab': True}).encode('utf8')
+        proxy.got_line(encoded)
+        treadmill.gssapiprotocol.GSSAPILineClient.write.assert_called_with(
+            b'xxx/my-hostname.my-domain'
+        )
+        treadmill.fs.write_safe.assert_called_with(
+            '/key/tab/dir/xxx',
+            mock.ANY,
+            owner=(1, 2)
+        )
+        treadmill.fs.write_safe.reset_mock()
+        encoded = json.dumps({}).encode('utf8')
+        proxy.got_line(encoded)
+        treadmill.gssapiprotocol.GSSAPILineClient.write.assert_called_with(
+            b'xxx/my-hostname.my-domain'
+        )
+        self.assertFalse(treadmill.fs.write_safe.called)
+
+    @mock.patch('treadmill.fs.write_safe', mock.Mock())
+    def test_write_keytab(self):
+        """Tests writing keytab."""
+        proxy = krb5keytabproxy.Krb5KeytabProxy(
+            'my-hostname.my-domain',
+            'my-ipa.domain',
+            ['kt-srv1:1234', 'kt-srv2:1234'],
+            '/key/tab/dir'
+        )
+        proxy.uid = 1
+        proxy.gid = 2
+        proxy.username = 'xxx'
+
+        proxy._write_keytab({
+            'result': {
+                'keytab_entries': base64.encodebytes(b'abc')
+            },
+        })
+
+        treadmill.fs.write_safe.assert_called_with(
+            '/key/tab/dir/xxx',
+            mock.ANY,
+            owner=(1, 2)
+        )


### PR DESCRIPTION
- treadmill krb5keytab - request <user>/<host> keytab via local
  krb5keytab proxy.
- treadmill admin krb5keytab - request keytab directly from the keytab
  server.
- treadmill sproc krb5keytab-proxy - run local proxy as root,
  authenticate requests using peercred protocol, forward request to
  krb5keytab server.