### PR TITLE
Add SASL support to Zookeeper bootstrap.

### DIFF
--- a/lib/python/treadmill_aws/bootstrap/node/aws.linux/env/TREADMILL_ZOOKEEPER
+++ b/lib/python/treadmill_aws/bootstrap/node/aws.linux/env/TREADMILL_ZOOKEEPER
@@ -1,1 +1,1 @@
-zookeeper://{% for master in masters %}{{ master['hostname'] }}:{{ master['zk-client-port'] }}{{ "," if not loop.last }}{% endfor %}/treadmill/{{ cell }}
+zookeeper.sasl://{{ treadmillid }}@{% for master in masters %}{{ master['hostname'] }}:{{ master['zk-client-port'] }}{{ "," if not loop.last }}{% endfor %}/treadmill/{{ cell }}

--- a/lib/python/treadmill_aws/bootstrap/zookeeper/aws.linux/treadmill/init/zk.yml
+++ b/lib/python/treadmill_aws/bootstrap/zookeeper/aws.linux/treadmill/init/zk.yml
@@ -4,17 +4,20 @@
 
 user: "{{ treadmillid }}"
 command: |
-  ZKROOT=/treadmill/zookeeper
+  {{ treadmill }}/bin/treadmill krb5keytab --keytab {{ keytab }}
+  klist -k {{ keytab }}
+  export KRB5KTNAME=FILE:{{ keytab }}
   for J in $(ls {{ zk_distro }}/*.jar); do
     CP=${CP:+$CP}:$J;
   done
   echo CLASSPATH: ${CP}
   exec \
     {{ java }} -cp ${CP} \
-    -Dlog4j.configuration=file://${ZKROOT}/conf/log4j.properties \
+    -Dlog4j.configuration=file://{{ zkroot }}/conf/log4j.properties \
+    -Djava.security.auth.login.config=/{{ zkroot }}/conf/jaas.conf \
     -Dcom.sun.management.jmxremote \
     -Dcom.sun.management.jmxremote.local.only=false \
-    org.apache.zookeeper.server.quorum.QuorumPeerMain ${ZKROOT}/conf/zoo.cfg
+    org.apache.zookeeper.server.quorum.QuorumPeerMain {{ zkroot }}/conf/zoo.cfg
 environ_dir: "/treadmill/env"
 monitor_policy:
   limit: "{{ restart_limit }}"

--- a/lib/python/treadmill_aws/bootstrap/zookeeper/aws.linux/treadmill/zookeeper/conf/jaas.conf
+++ b/lib/python/treadmill_aws/bootstrap/zookeeper/aws.linux/treadmill/zookeeper/conf/jaas.conf
@@ -4,7 +4,7 @@ Server {
        keyTab="{{ keytab }}"
        storeKey=true
        useTicketCache=false
-       debug=false
+       debug=true
        principal="{{ treadmillid }}/{{ me.hostname }}@{{ krb_realm }}";
 };
 
@@ -14,7 +14,7 @@ QuorumServer {
        keyTab="{{ keytab }}"
        storeKey=true
        useTicketCache=false
-       debug=false
+       debug=true
        principal="{{ treadmillid }}/{{ me.hostname }}@{{ krb_realm }}";
 };
 
@@ -24,6 +24,6 @@ QuorumLearner {
        keyTab="{{ keytab }}"
        storeKey=true
        useTicketCache=false
-       debug=false
+       debug=true
        principal="{{ treadmillid }}/{{ me.hostname }}@{{ krb_realm }}";
 };

--- a/lib/python/treadmill_aws/bootstrap/zookeeper/aws.linux/treadmill/zookeeper/conf/zoo.cfg
+++ b/lib/python/treadmill_aws/bootstrap/zookeeper/aws.linux/treadmill/zookeeper/conf/zoo.cfg
@@ -14,15 +14,14 @@ syncLimit={{ sync_limit }}
 maxClientCnxns={{ max_client_cnxns }}
 
 # TODO: add Treadmill role authorizer.
-#
-# TODO: enable SASL auth when keytab config is finalized.
-# authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
+authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
+requireClientAuthScheme=sasl
 
 jaasLoginRenew={{ jaas_login_renew }}
 
-# quorum.auth.enableSasl=true
-# quorum.auth.learnerRequireSasl=true
-# quorum.auth.serverRequireSasl=true
+quorum.auth.enableSasl=true
+quorum.auth.learnerRequireSasl=true
+quorum.auth.serverRequireSasl=true
 quorum.auth.learner.loginContext=QuorumLearner
 quorum.auth.server.loginContext=QuorumServer
 quorum.auth.kerberos.servicePrincipal={{ treadmillid }}/_HOST

--- a/lib/python/treadmill_aws/bootstrap/zookeeper/aws.py
+++ b/lib/python/treadmill_aws/bootstrap/zookeeper/aws.py
@@ -23,6 +23,8 @@ DEFAULTS = {
     'restart_interval': 300,
     'restart_limit': 5,
     'zk_distro': '/opt/zookeeper',
+    'keytab': '/treadmill/zookeeper/zookeeper.keytab',
+    'zkroot': '/treadmill/zookeeper',
 }
 
 ALIASES = aliases.ALIASES

--- a/tests/zookeeper_test.py
+++ b/tests/zookeeper_test.py
@@ -67,19 +67,31 @@ class ZookeeperTest(unittest.TestCase):
         zk = zksasl.SASLZkClient()
         zk.make_role_acl('servers', 'ra')
 
+        # TODO: re-enable when role support is added.
+        #
+        # make_acl_mock.assert_called_once_with(
+        #    scheme='sasl', credential='role/servers', read=True,
+        #    write=False, delete=False, create=False, admin=True
+        # )
         make_acl_mock.assert_called_once_with(
-            scheme='sasl', credential='role/servers', read=True,
-            write=False, delete=False, create=False, admin=True
+            'world', 'anyone',
+            read=True,
+            write=False,
+            delete=False,
+            create=False,
+            admin=True
         )
 
     @mock.patch('kazoo.security.make_acl')
+    @mock.patch('treadmill.syscall.krb5.get_host_realm',
+                mock.Mock(return_value=['my-realm']))
     def test_make_host_acl(self, make_acl_mock):
         """Test host acl."""
         zk = zksasl.SASLZkClient()
-        zk.make_host_acl('foo@123', 'rdwca')
+        zk.make_host_acl('foo', 'rdwca')
 
         make_acl_mock.assert_called_once_with(
-            scheme='sasl', credential='host/foo@123', read=True,
+            scheme='sasl', credential='host/foo@my-realm', read=True,
             write=True, delete=True, create=True, admin=True
         )
 


### PR DESCRIPTION
- Request Zookeeper keytabs on start. It is assumed that
  krb5keytab-proxy service is started on the host by systemd.
- Properly construct user/host ACLs, to include full kerberos realm.

TODO: consider alternative configuration, when krb5keytab-proxy is part
      of Zookeeper supervision tree.