### PR TITLE
Change default instance disk type to SSD

### DIFF
--- a/lib/python/treadmill_aws/ec2client.py
+++ b/lib/python/treadmill_aws/ec2client.py
@@ -24,7 +24,7 @@ def create_instance(ec2_conn, user_data, image_id, instance_type,
         }],
         'BlockDeviceMappings': [{
             'DeviceName': '/dev/sda1',
-            'Ebs': {'VolumeSize': disk}}]
+            'Ebs': {'VolumeSize': disk, 'VolumeType': 'gp2'}}]
     }
 
     if instance_profile:

--- a/tests/ec2client_test.py
+++ b/tests/ec2client_test.py
@@ -44,7 +44,8 @@ class EC2ClientTest(unittest.TestCase):
             TagSpecifications=[],
             UserData='foo',
             BlockDeviceMappings=[{'DeviceName': '/dev/sda1',
-                                  'Ebs': {'VolumeSize': 1}}]
+                                  'Ebs': {'VolumeSize': 1,
+                                          'VolumeType': 'gp2'}}]
         )
 
     @mock.patch('treadmill_aws.ec2client.list_instances',


### PR DESCRIPTION
Changes the default EC2 disk type from magnetic to GP2 (non-provisioned SSD). 
They cost the same amount and have 1/3 to 1/10 the IOPS performance. 