### PR TITLE
Clarified error message

### DIFF
--- a/lib/python/treadmill_aws/ec2client.py
+++ b/lib/python/treadmill_aws/ec2client.py
@@ -132,7 +132,12 @@ def get_image(ec2_conn, ids=None, tags=None, owners=None, name=None):
     )
 
     if not images:
-        raise exc.NotFoundError('No {} found.'.format(ids))
+        if ids:
+            raise exc.NotFoundError('No image id {} found.'.format(ids))
+        if tags:
+            raise exc.NotFoundError('No image tagged {} found.'.format(tags))
+        if name:
+            raise exc.NotFoundError('No image named {} found.'.format(name))
 
     image = images.pop(0)
     if images:


### PR DESCRIPTION
More user-friendly error messages; currently this outputs an error like the following:
treadmill.exc.NotFoundError: No None found.
