### PR TITLE
Patch: Create instance pulls the key from the instance metadata where…

### DIFF
--- a/lib/python/treadmill_aws/cli/admin/aws/instance.py
+++ b/lib/python/treadmill_aws/cli/admin/aws/instance.py
@@ -145,9 +145,6 @@ def init():
         else:
             instance_vars = {}
 
-        if not key:
-            key = metadata.instance_keys()[0]
-
         hosts_created = hostmanager.create_host(
             ipa_client=ipa_client,
             ec2_conn=ec2_conn,


### PR DESCRIPTION
Patch: Create instance pulls the key from the instance userdata where the treadmill cli runs, that model doesnt work with multiple AWS accounts.

Example: if we run treadmill cli from devel02 host in AWS Test account to create an instance in AWS Shared account the public ssh key metadata will be pulled from the devel02 instance userdata and that will cause an exception because the private ssh key in AWS Shared account doesnt exist.