### PR TITLE
Use relative dns names when setting ipa srv recs.

### DIFF
--- a/lib/python/treadmill_aws/cli/admin/ipa.py
+++ b/lib/python/treadmill_aws/cli/admin/ipa.py
@@ -86,10 +86,8 @@ def init():
     @cli.handle_exceptions(_CLI_EXCEPTIONS)
     def krb5keytab(add, remove):
         """Manage krb5keytab configuration."""
-        domain = awscontext.GLOBAL.ipa_domain
         ipaclient = awscontext.GLOBAL.ipaclient
-
-        idnsname = '_krb5keytab._tcp.{}'.format(domain)
+        idnsname = '_krb5keytab._tcp'
         for endpoint in sorted(_set_state(ipaclient, idnsname, add, remove)):
             print(endpoint)
 

--- a/lib/python/treadmill_aws/ipaclient.py
+++ b/lib/python/treadmill_aws/ipaclient.py
@@ -271,7 +271,7 @@ class IPAClient():
 
     def add_srv_record(self, idnsname, host, port, weight=0, priority=0):
         """Add SRV record."""
-        record = '{weight} {priority} {port} {host}.'.format(
+        record = '{weight} {priority} {port} {host}'.format(
             weight=weight,
             priority=priority,
             port=port,
@@ -286,7 +286,7 @@ class IPAClient():
 
     def delete_srv_record(self, idnsname, host, port, weight=0, priority=0):
         """Add SRV record."""
-        record = '{weight} {priority} {port} {host}.'.format(
+        record = '{weight} {priority} {port} {host}'.format(
             weight=weight,
             priority=priority,
             port=port,


### PR DESCRIPTION
- Fix ipaclient not to append . to hostname when creating srv records.
- Fix cli/admin/ipa not to use dns domain for srv record name, assume
  default domain.