### PR TITLE
Add CLI tools to manage cell data.

### DIFF
--- a/entry_points.txt
+++ b/entry_points.txt
@@ -31,6 +31,10 @@ configure-monitors = treadmill_aws.cli.admin.cell.configure_monitors
 configure-appgroups = treadmill_aws.cli.admin.cell.configure_appgroups
 configure-dns = treadmill_aws.cli.admin.cell.configure_dns
 restart-apps = treadmill_aws.cli.admin.cell.restart_apps
+subnet = treadmill_aws.cli.admin.cell.subnet
+docker = treadmill_aws.cli.admin.cell.docker
+image = treadmill_aws.cli.admin.cell.image
+realm = treadmill_aws.cli.admin.cell.realm
 
 [treadmill_aws.cli.aws]
 image = treadmill_aws.cli.aws.image

--- a/lib/python/treadmill_aws/cli/admin/cell/docker.py
+++ b/lib/python/treadmill_aws/cli/admin/cell/docker.py
@@ -1,0 +1,44 @@
+"""Admin module to manage cell Docker registries.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+
+import click
+
+from treadmill import admin
+from treadmill import context
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def init():
+    """Admin Cell CLI module"""
+
+    @click.command(name='docker')
+    @click.option('--add', multiple=True, help='Docker registry to add.')
+    @click.option('--remove', multiple=True, help='Docker registry to remove.')
+    def docker(add, remove):
+        """Configure cell docker registries."""
+        admin_cell = admin.Cell(context.GLOBAL.ldap.conn)
+        cell = admin_cell.get(context.GLOBAL.cell)
+        data = cell.get('data', {})
+        registries = set(data.get('docker_registries', []))
+
+        for registry in add:
+            registries.add(registry)
+        for registry in remove:
+            registries.discard(registry)
+
+        data['docker_registries'] = list(registries)
+        admin_cell.update(context.GLOBAL.cell, {'data': data})
+
+        for registry in registries:
+            print(registry)
+
+    return docker

--- a/lib/python/treadmill_aws/cli/admin/cell/image.py
+++ b/lib/python/treadmill_aws/cli/admin/cell/image.py
@@ -1,0 +1,36 @@
+"""Admin module to manage cell AMIs.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+
+import click
+
+from treadmill import admin
+from treadmill import context
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def init():
+    """Admin Cell CLI module"""
+
+    @click.command(name='image')
+    @click.option('--image', help='AMI image.')
+    def image_cmd(image):
+        """Configure cell AMI image."""
+        admin_cell = admin.Cell(context.GLOBAL.ldap.conn)
+        cell = admin_cell.get(context.GLOBAL.cell)
+        data = cell.get('data', {})
+        if image:
+            data['image'] = image
+
+        admin_cell.update(context.GLOBAL.cell, {'data': data})
+        print(data.get('image', ''))
+
+    return image_cmd

--- a/lib/python/treadmill_aws/cli/admin/cell/realm.py
+++ b/lib/python/treadmill_aws/cli/admin/cell/realm.py
@@ -1,0 +1,36 @@
+"""Admin module to manage cell Kerberos realm.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+
+import click
+
+from treadmill import admin
+from treadmill import context
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def init():
+    """Admin Cell CLI module"""
+
+    @click.command(name='realm')
+    @click.option('--realm', help='Kerberos realm.')
+    def realm_cmd(realm):
+        """Configure cell kerberos realm."""
+        admin_cell = admin.Cell(context.GLOBAL.ldap.conn)
+        cell = admin_cell.get(context.GLOBAL.cell)
+        data = cell.get('data', {})
+        if realm:
+            data['realm'] = realm
+
+        admin_cell.update(context.GLOBAL.cell, {'data': data})
+        print(data.get('realm', ''))
+
+    return realm_cmd

--- a/lib/python/treadmill_aws/cli/admin/cell/subnet.py
+++ b/lib/python/treadmill_aws/cli/admin/cell/subnet.py
@@ -1,0 +1,44 @@
+"""Admin module to manage cell subnets.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+
+import click
+
+from treadmill import admin
+from treadmill import context
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def init():
+    """Admin Cell CLI module"""
+
+    @click.command(name='subnet')
+    @click.option('--add', multiple=True, help='Subnet to add.')
+    @click.option('--remove', multiple=True, help='Subnet to remove.')
+    def subnet_cmd(add, remove):
+        """Configure cell subnets."""
+        admin_cell = admin.Cell(context.GLOBAL.ldap.conn)
+        cell = admin_cell.get(context.GLOBAL.cell)
+        data = cell.get('data', {})
+        subnets = set(data.get('subnets', []))
+
+        for subnet in add:
+            subnets.add(subnet)
+        for subnet in remove:
+            subnets.discard(subnet)
+
+        data['subnets'] = list(subnets)
+        admin_cell.update(context.GLOBAL.cell, {'data': data})
+
+        for subnet in subnets:
+            print(subnet)
+
+    return subnet_cmd


### PR DESCRIPTION
- treadmill admin aws cell commands:
  docker - manage docker registries
  subnets - manage list of EC2 subnets for the cell
  realm - set cell kerberos realm
  image - set default AMI for cell nodes.

The data will be used to automate deployment of cell infrastructure.