### PR TITLE
Add api_scope to AWS profile

### DIFF
--- a/lib/python/treadmill_aws/plugins/profile.py
+++ b/lib/python/treadmill_aws/plugins/profile.py
@@ -1,4 +1,19 @@
-"""AWS Profile."""
+"""AWS profile plugin.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+
+
+def api_scope():
+    """Returns admin API DNS scope."""
+    return [os.environ.get('TREADMILL_CELL', 'na') + '.' + 'cell']
+
 
 PROFILE = {
+    'api_scope': api_scope()
 }


### PR DESCRIPTION
This is necessary for dnscontext to be able to resolve the admin API. 