### PR TITLE
Docker registry as init1 service

### DIFF
--- a/lib/python/treadmill_aws/bootstrap/node/aws.linux/init/registry.yml
+++ b/lib/python/treadmill_aws/bootstrap/node/aws.linux/init/registry.yml
@@ -1,0 +1,43 @@
+command: |
+  exec /usr/bin/registry serve etc/config.yml
+
+data_dir:
+- path: etc/config.yml
+  content: |
+    # Docker Registry Configuration
+    version: 0.1
+
+    http:
+      addr: 192.168.254.254:5000
+
+    log:
+      accesslog:
+        disabled: true
+      level: debug
+      formatter: text
+      fields:
+        service: registry
+        environment: infra
+
+    storage:
+      s3:
+        region: {{ data.s3_registry_region }}
+        bucket: {{ data.s3_registry_bucket }}
+        secure: true
+        chunksize: 5242880
+        multipartcopychunksize: 33554432
+        multipartcopymaxconcurrency: 100
+        multipartcopythresholdsize: 33554432
+
+      maintenance:
+        uploadpurging:
+          enabled: false
+        readonly:
+          enabled: true
+
+environ_dir: "{{ dir }}/env"
+monitor_policy:
+  limit: 1
+  interval: 60
+  tombstone:
+    path: "{{ dir }}/tombstones/init"

--- a/lib/python/treadmill_aws/cli/admin/cell/configure_data.py
+++ b/lib/python/treadmill_aws/cli/admin/cell/configure_data.py
@@ -47,6 +47,8 @@ def init():
     @click.option('--realm', help='Nodes kerberos realm.')
     @click.option('--instance-profile', help='Instance profile.')
     @click.option('--subnets', help='List of subnets.', type=cli.LIST)
+    @click.option('--s3-registry-region', help='S3 registry bucket region.')
+    @click.option('--s3-registry-bucket', help='S3 registry bucket name.')
     def configure_data_cmd(docker_registries,
                            image,
                            disk_size,
@@ -55,7 +57,9 @@ def init():
                            secgroup,
                            realm,
                            instance_profile,
-                           subnets):
+                           subnets,
+                           s3_registry_region,
+                           s3_registry_bucket):
         """Configure cell data."""
         admin_cell = admin.Cell(context.GLOBAL.ldap.conn)
         cell = admin_cell.get(context.GLOBAL.cell)
@@ -70,10 +74,15 @@ def init():
         modified = _set(data, 'realm', realm) or modified
         modified = _set(data, 'instance_profile', instance_profile) or modified
         modified = _set(data, 'subnets', subnets) or modified
+        modified = _set(data,
+                        's3_registry_region',
+                        s3_registry_region) or modified
+        modified = _set(data,
+                        's3_registry_bucket',
+                        s3_registry_bucket) or modified
 
         if modified:
             admin_cell.update(context.GLOBAL.cell, {'data': data})
-
         cli.out(formatter(data))
 
     return configure_data_cmd

--- a/lib/python/treadmill_aws/formatter.py
+++ b/lib/python/treadmill_aws/formatter.py
@@ -279,6 +279,8 @@ class CellDataFormatter:
             ('realm', 'realm', None),
             ('instance-profile', 'instance_profile', None),
             ('subnets', 'subnets', ','.join),
+            ('s3_registry_region', 's3_registry_region', None),
+            ('s3_registry_bucket', 's3_registry_bucket', None),
         ]
 
         format_item = tablefmt.make_dict_to_table(schema)


### PR DESCRIPTION
This sets up an s3-backed Docker registry running in init1 on Treadmill nodes. 
I also added hooks to write the keys S3_DOCKER_BUCKET and S3_REGION to the cell record in LDAP. 