### PR TITLE
Spot placement should be optional

### DIFF
--- a/lib/python/treadmill_aws/cli/admin/aws/instance.py
+++ b/lib/python/treadmill_aws/cli/admin/aws/instance.py
@@ -124,15 +124,15 @@ def init():
         help='Elastic Network ID; e.g. eni-xxxxxxxx',
     )
     @click.option(
-        '--on-demand',
+        '--spot',
         is_flag=True,
         required=False,
-        help='Request an on_demand instance',
+        help='Request a spot instance',
     )
     @treadmill_aws.cli.admin.aws.ON_AWS_EXCEPTIONS
     def create(
             image, image_account, count, disk_size, key, role, ip_address, eni,
-            on_demand, secgroup, size, subnet, data, instance_profile,
+            spot, secgroup, size, subnet, data, instance_profile,
             hostgroup, hostname):
         """Create instance(s)"""
         ipa_client = awscontext.GLOBAL.ipaclient
@@ -169,7 +169,7 @@ def init():
             hostname=hostname,
             ip_address=ip_address,
             eni=eni,
-            on_demand=on_demand
+            spot=spot
         )
         for host_created in hosts_created:
             click.echo(host_created)

--- a/lib/python/treadmill_aws/ec2client.py
+++ b/lib/python/treadmill_aws/ec2client.py
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 def create_instance(ec2_conn, user_data, image_id, instance_type,
                     tags, secgroup_ids, subnet_id, disk, key=None,
                     instance_profile=None, ip_address=None, eni=None,
-                    on_demand=False):
+                    spot=False):
     """Create new instance."""
     args = {
         'TagSpecifications': tags,
@@ -32,7 +32,7 @@ def create_instance(ec2_conn, user_data, image_id, instance_type,
             'Ebs': {'VolumeSize': disk, 'VolumeType': 'gp2'}}]
     }
 
-    if not on_demand:
+    if spot:
         args['InstanceMarketOptions'] = {
             'MarketType': 'spot',
             'SpotOptions': {

--- a/lib/python/treadmill_aws/hostmanager.py
+++ b/lib/python/treadmill_aws/hostmanager.py
@@ -69,7 +69,7 @@ def create_host(ec2_conn, ipa_client, image_id, count, domain,
                 secgroup_ids, instance_type, subnets, disk,
                 instance_vars, role=None, instance_profile=None,
                 hostgroups=None, hostname=None, ip_address=None,
-                eni=None, key=None, tags=None, on_demand=False):
+                eni=None, key=None, tags=None, spot=False):
     """Adds host defined in manifest to IPA, then adds the OTP from the
        IPA reply to the manifest and creates EC2 instance.
     """
@@ -137,7 +137,7 @@ def create_host(ec2_conn, ipa_client, image_id, count, domain,
                     disk=disk,
                     ip_address=ip_address,
                     eni=eni,
-                    on_demand=on_demand
+                    spot=spot
                 )
                 hosts.append(host_ctx['hostname'])
                 break

--- a/tests/ec2client_test.py
+++ b/tests/ec2client_test.py
@@ -29,7 +29,7 @@ class EC2ClientTest(unittest.TestCase):
             secgroup_ids='sg-foo12345',
             subnet_id='subnet-foo12345',
             disk=1,
-            on_demand=True
+            spot=False
         )
 
         self.assertEqual(ec2_conn.run_instances.call_count, 1)
@@ -61,7 +61,7 @@ class EC2ClientTest(unittest.TestCase):
             secgroup_ids='sg-foo12345',
             subnet_id='subnet-foo12345',
             disk=1,
-            on_demand=False
+            spot=True
         )
 
         self.assertEqual(ec2_conn.run_instances.call_count, 1)


### PR DESCRIPTION
Spot placement should be an optional attribute, explicitly set as an attribute on cell partitions or set by system processes like Autoscaler that deal with ephemeral servers. If it is the default behavior, we will need to exclude Spot from the infra that is not intended to be ephemeral (i.e. system partitions, zookeepers, LDAP, IPA, DNS, etc) that is managed by Treadmill. 