### PR TITLE
Kill node (unregister app and server presence) before deleting host. …

### DIFF
--- a/lib/python/treadmill_aws/hostmanager.py
+++ b/lib/python/treadmill_aws/hostmanager.py
@@ -161,18 +161,19 @@ def delete_hosts(ec2_conn, ipa_client, hostnames):
         selected using filters (200); delete instances in batches of
         _EC2_DELETE_BATCH
     """
+    _LOGGER.debug('Delete instances: %r', hostnames)
+    hostnames_left = hostnames[:]
+    while hostnames_left:
+        batch = hostnames_left[:_EC2_DELETE_BATCH]
+        hostnames_left = hostnames_left[_EC2_DELETE_BATCH:]
+        ec2client.delete_instances(ec2_conn=ec2_conn, hostnames=batch)
+
     for hostname in hostnames:
         _LOGGER.debug('Unenroll host from IPA: %s', hostname)
         try:
             ipa_client.unenroll_host(hostname=hostname)
         except (KeyError, ipaclient.NotFoundError):
             _LOGGER.debug('Host not found: %s', hostname)
-
-    _LOGGER.debug('Delete instances: %r', hostnames)
-    while hostnames:
-        batch = hostnames[:_EC2_DELETE_BATCH]
-        hostnames = hostnames[_EC2_DELETE_BATCH:]
-        ec2client.delete_instances(ec2_conn=ec2_conn, hostnames=batch)
 
 
 def find_hosts(ipa_client, pattern=None):

--- a/lib/python/treadmill_aws/sproc/autoscale.py
+++ b/lib/python/treadmill_aws/sproc/autoscale.py
@@ -6,6 +6,9 @@ import time
 
 import click
 
+from treadmill import context
+from treadmill import zkutils
+
 from treadmill_aws import cli as aws_cli
 from treadmill_aws import autoscale
 
@@ -47,6 +50,8 @@ def init():
         if workers:
             pool = multiprocessing.Pool(processes=workers)
             pool.workers = workers
+
+        context.GLOBAL.zk.add_listener(zkutils.exit_on_lost)
 
         while True:
             autoscale.scale(server_app_ratio, pool=pool)


### PR DESCRIPTION
…When deleting host, delete ec2 instance first and then unenroll from ipa. Don't delete blackedout or frozen servers.