### PR TITLE
Lock & cache keytabs requested from IPA.

### DIFF
--- a/lib/python/treadmill_aws/features/krb5keytab.py
+++ b/lib/python/treadmill_aws/features/krb5keytab.py
@@ -44,6 +44,8 @@ class Krb5KeytabFeature(feature_base.Feature):
                 ' --owner {user}'
                 ' --principal {user}/{hostname}'
                 ' --keytab {appdir}/var/spool/keytabs/{user}'
+                ' --cachedir /tmp'
+                ' --lockdir /tmp'
                 '; exec sleep inf'
             ).format(
                 treadmill=subproc.resolve('treadmill'),


### PR DESCRIPTION
To avoid race condition when multiple containers on the same host
request same keytab from IPA, serialize krb5keytab requests and use
local cache. If the keytab is available locally, use it.

TODO: Possible enhancement - check keytab validity (need to establish
sec context to validate that keytab version is current.)